### PR TITLE
Add contribution docs and GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report a reproducible problem with the skill or generated workflow
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please include enough detail for someone else to reproduce it.
+
+  - type: input
+    id: environment
+    attributes:
+      label: Agent and environment
+      description: Which agent/editor/runtime were you using?
+      placeholder: Cursor on macOS, Claude Code on Linux, etc.
+    validations:
+      required: true
+
+  - type: input
+    id: install_method
+    attributes:
+      label: Install method
+      description: How did you install the skill?
+      placeholder: npx skills add ..., manual clone, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: prompt
+    attributes:
+      label: Prompt used
+      description: Paste the prompt or request that triggered the issue
+      placeholder: Build App Store screenshots for my app...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Include screenshots, exports, console output, or generated files if relevant
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest an improvement to the skill, docs, or workflow
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the user problem first, then the proposed solution.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What real workflow or quality gap does this feature address?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should change in the repo or skill behavior?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or other ideas you considered
+
+  - type: textarea
+    id: extra_context
+    attributes:
+      label: Additional context
+      description: Example prompts, screenshots, references, or prior art

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+- explain the problem this PR solves
+- explain the change in skill/docs behavior
+
+## Validation
+
+- describe how you tested the change
+- include the prompt or scenario you used if `SKILL.md` changed
+
+## Checklist
+
+- [ ] I checked open PRs/issues for overlap
+- [ ] I kept `README.md` and `SKILL.md` aligned where needed
+- [ ] I tested the changed workflow or documented why testing was not possible

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing
+
+Thanks for contributing to `app-store-screenshots`.
+
+This repository is intentionally small, but changes still affect real agent behavior. Most contributions here change either:
+
+- `README.md`: how humans discover and install the skill
+- `skills/app-store-screenshots/SKILL.md`: how coding agents actually behave
+
+## What Makes a Good Contribution
+
+- Fixes a real workflow problem for people generating App Store screenshots
+- Improves the quality or reliability of the generated output
+- Makes the skill easier to use across agents and environments
+- Keeps the skill opinionated, but still user-driven
+
+## Scope Guidelines
+
+Good fit:
+
+- Better export reliability
+- Better prompt flow and requirements gathering
+- Stronger copy/design guidance
+- Better contributor ergonomics
+- Clearer installation or usage docs
+
+Usually not a fit:
+
+- Hardcoded brand styles
+- Repo-specific assumptions that do not generalize
+- Large framework additions outside the skill's purpose
+- Changes that make the skill significantly more verbose without improving outcomes
+
+## Before Opening a PR
+
+1. Check open PRs to avoid overlapping work.
+2. Read both `README.md` and `skills/app-store-screenshots/SKILL.md`.
+3. Keep user-facing docs and skill behavior aligned when applicable.
+
+## Testing Changes
+
+There is no traditional automated test suite in this repository, so use a manual smoke-test checklist.
+
+### For README-only changes
+
+- Confirm installation instructions still make sense
+- Confirm example paths and commands are copy-pasteable
+
+### For `SKILL.md` changes
+
+Validate the skill against at least one realistic scenario:
+
+1. Start from an empty folder
+2. Ask an agent to generate App Store screenshots for a sample app
+3. Confirm the skill:
+   - asks the required discovery questions first
+   - preserves the "screenshots are ads, not docs" principle
+   - keeps the generator architecture coherent
+   - produces export instructions that are internally consistent
+
+### Strongly Recommended
+
+Include in your PR description:
+
+- the prompt you used to test the skill
+- what behavior changed
+- what stayed intentionally unchanged
+
+## Authoring Guidelines
+
+- Prefer compact, high-signal instructions over long prose
+- Keep examples realistic and production-oriented
+- Avoid duplicating large blocks between `README.md` and `SKILL.md` unless the duplication helps different audiences
+- If a change modifies workflow expectations, document it in both files when relevant
+
+## Pull Request Checklist
+
+Before submitting, verify:
+
+- the change solves a concrete problem
+- the wording is clear for both humans and agents
+- README and SKILL instructions do not contradict each other
+- the PR description explains why the change is useful

--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ Screenshots are designed at 1320x2868 (largest) and scaled down for smaller size
 - Node.js 18+
 - One of: bun, pnpm, yarn, or npm (detected automatically, bun preferred)
 
+## Contributing
+
+Contributions are welcome, especially around:
+
+- screenshot generation reliability
+- skill prompt quality
+- clearer docs and onboarding
+- cross-agent compatibility
+
+If you want to contribute, start with `CONTRIBUTING.md`. Bug reports and feature requests also have issue templates now to make reproduction and review easier.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

This PR adds a small but high-leverage contributor workflow layer to the repository.

### What it adds

- `CONTRIBUTING.md` with scope guidance, manual testing guidance, and expectations for README / `SKILL.md` sync
- GitHub issue forms for bug reports and feature requests
- `.github/ISSUE_TEMPLATE/config.yml` to disable unstructured blank issues
- `.github/pull_request_template.md` to make PRs easier to review
- A short `README.md` contributing section pointing people to the new workflow

## Why this is useful

This repository is intentionally small, but changes here directly affect how coding agents behave in real projects. Right now contributors have no structured path for:

- reporting reproducible bugs
- proposing features with clear problem statements
- explaining how `SKILL.md` changes were validated

Adding lightweight templates helps keep future issues and PRs actionable, which should be especially helpful as the repo gets more visibility and outside contributions.

## Validation

- Verified the new files are present and linked from the README
- Confirmed there are no local linter diagnostics in the repo after the changes
