### PR TITLE
Add a final QA checklist for screenshot generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ Screenshots are designed at 1320x2868 (largest) and scaled down for smaller size
 - **Layouts vary** — no two adjacent slides share the same phone placement
 - **Style is user-driven** — no hardcoded colors, gradients, or fonts
 
+## Quality Checklist
+
+Before exporting, each slide should pass this quick review:
+
+- the headline communicates one idea in about one second
+- the first slide sells the strongest user benefit
+- adjacent slides do not reuse the same layout
+- decorative elements support the message instead of blocking the UI
+- text, screenshots, and framing still look correct after export sizing
+
 ## Requirements
 
 - Node.js 18+

--- a/skills/app-store-screenshots/SKILL.md
+++ b/skills/app-store-screenshots/SKILL.md
@@ -401,6 +401,36 @@ el.style.zIndex = "";
 - Set `fontFamily` on the offscreen container.
 - **Numbered filenames**: Prefix exports with zero-padded index so they sort correctly: `01-hero-1320x2868.png`, `02-freshness-1320x2868.png`, etc. Use `String(index + 1).padStart(2, "0")`.
 
+## Step 7: Final QA Gate
+
+Before handing the page back to the user, review every slide against this checklist:
+
+### Message Quality
+
+- **One idea per slide**: if a headline sells two ideas, split it or simplify it
+- **First slide is strongest**: the hero slide should communicate the main benefit immediately
+- **Readable in one second**: if you cannot parse it instantly at arm's length, rewrite it
+
+### Visual Quality
+
+- **No repeated layouts in sequence**: adjacent slides should not feel templated
+- **Decorative elements support the story**: they should add energy without covering the app UI
+- **Visual rhythm exists**: include at least one contrast slide when the set is long enough
+
+### Export Quality
+
+- **No clipped text or assets** after scaling to the selected export size
+- **Screenshots are correctly aligned** inside the phone or iPad frame
+- **Filenames sort correctly** with zero-padded numeric prefixes
+
+### Hand-off Behavior
+
+When you present the finished work:
+
+1. briefly explain the narrative arc across the slides
+2. mention any slides that intentionally use contrast or different layout treatment
+3. call out any assumptions you made about brand tone, copy, or missing assets
+
 ## Common Mistakes
 
 | Mistake | Fix |


### PR DESCRIPTION
## Summary

This PR adds a clear final quality gate to both the README and `SKILL.md` so screenshot sets are reviewed consistently before hand-off/export.

## What changed

- Added a short `README.md` quality checklist for human readers
- Added a dedicated `Step 7: Final QA Gate` section to `skills/app-store-screenshots/SKILL.md`
- The new checklist covers:
  - message quality
  - visual quality
  - export quality
  - hand-off expectations

## Why this is useful

The current skill already has strong design and export guidance, but it does not explicitly tell agents to pause and review the final set as a system before returning it. A lightweight QA gate helps prevent common quality regressions such as:

- weak first slides
- repeated layouts across adjacent slides
- overly complex headlines
- clipped text after export scaling
- missing explanation of assumptions during hand-off

This keeps the repo small while making output quality more consistent.

## Validation

- Reviewed README / `SKILL.md` alignment
- Confirmed there are no local linter diagnostics in the repo after the changes
