### PR TITLE
Add example prompts and copy rewrite patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,50 @@ Or just tell Claude Code what you need:
 
 Claude will ask you about your app's screenshots, brand colors, font, features, style direction, and number of slides before building anything.
 
+## Example prompts
+
+These are good starting prompts because they provide product context while still leaving room for the skill to guide the design process.
+
+### Habit tracker
+
+```text
+Build App Store screenshots for my habit tracker.
+The app helps people stay consistent with simple daily routines.
+I want 6 slides, clean/minimal style, warm neutrals, and a calm premium feel.
+```
+
+### Finance app
+
+```text
+Generate App Store screenshots for my personal finance app.
+The app's main strengths are fast expense capture, clear monthly trends, and shared budgets.
+I want a sharp, modern style with high contrast and 7 slides.
+```
+
+### AI productivity tool
+
+```text
+Create exportable App Store screenshots for my AI note-taking app.
+The core value is turning messy voice notes into clean summaries and action items.
+I want bold copy, dark backgrounds, and a polished tech-forward look.
+```
+
+### Wellness app
+
+```text
+Build marketing screenshots for my meditation app.
+The app focuses on sleep, stress relief, and short guided sessions.
+Use a soft, warm, organic style and prioritize emotional outcomes over feature lists.
+```
+
+## Better prompt tips
+
+- say what the app does in one sentence
+- list the top 3-5 features in priority order
+- describe the visual style you want
+- mention how many slides you need
+- provide references if you want the output to match a certain App Store style
+
 ## What gets scaffolded
 
 If starting from an empty folder, the skill creates:

--- a/skills/app-store-screenshots/SKILL.md
+++ b/skills/app-store-screenshots/SKILL.md
@@ -163,12 +163,53 @@ Get all headlines approved before building layouts. Bad copy ruins good design.
 - **Vague aspirational**: "Every item, tracked"
 - **Marketing buzzwords**: "AI-powered tips" (unless it's actually AI)
 
+### Bad-to-Better Headline Examples
+
+Use these patterns to rewrite weak copy before building any layout:
+
+| Weak | Better | Why it wins |
+|------|--------|-------------|
+| Track habits and stay motivated | Keep your streak alive | one idea, faster to parse |
+| Organize tasks with AI summaries and smart sorting | Turn notes into next steps | outcome-first, less jargon |
+| Save recipes with tags, filters, and favorites | Find dinner fast | sells the user benefit, not the UI |
+| Manage budgets and never miss payments | See where money goes | cleaner promise, no dual claim |
+| AI-powered wellness support | Feel calmer tonight | concrete emotional outcome |
+
 ### Copy Process
 
 1. Write 3 options per slide using the three approaches
 2. Read each at arm's length — if you can't parse it in 1 second, it's too complex
 3. Check: does each line have 3-5 words? If not, adjust line breaks
 4. Present options to the user with reasoning for each
+
+### Example Prompt Shapes
+
+If the user gives a weak or underspecified request, reshape it internally into something like:
+
+```text
+Build App Store screenshots for my habit tracker.
+The app helps people stay consistent with simple daily routines.
+I want 6 slides, clean/minimal style, warm neutrals, and a calm premium feel.
+```
+
+```text
+Generate App Store screenshots for my personal finance app.
+The app's main strengths are fast expense capture, clear monthly trends, and shared budgets.
+I want a sharp, modern style with high contrast and 7 slides.
+```
+
+```text
+Create exportable App Store screenshots for my AI note-taking app.
+The core value is turning messy voice notes into clean summaries and action items.
+I want bold copy, dark backgrounds, and a polished tech-forward look.
+```
+
+The pattern is:
+
+1. app category + core outcome
+2. top features in priority order
+3. desired slide count
+4. style direction
 
 ### Reference Apps for Copy Style
 


### PR DESCRIPTION
## Summary

This PR improves the repo's practical guidance for both users and agents by adding:

- example prompts in `README.md`
- a short "better prompt" guide in `README.md`
- bad-to-better headline rewrite examples in `skills/app-store-screenshots/SKILL.md`
- reusable prompt-shape examples in `skills/app-store-screenshots/SKILL.md`

## Why this is useful

The skill already has strong principles, but users still need help getting from:

- vague product descriptions
- feature-list style copy
- underspecified requests

...to the kind of clear, outcome-first inputs that produce strong App Store screenshots.

These additions make the repo more actionable without changing its core behavior. They also help contributors and agents preserve the repo's "screenshots are ads, not docs" philosophy in a more concrete way.

## Validation

- Reviewed README and `SKILL.md` together to keep the examples aligned
- Confirmed there are no local linter diagnostics in the repo after the changes
