### PR TITLE
feat: add runnable Next.js starter template with professional export UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A skill for AI-powered coding agents (Claude Code, Cursor, Windsurf, etc.) that 
 - Writes compelling copy using proven App Store copywriting patterns
 - Renders screenshots at full resolution with a built-in iPhone mockup
 - Exports PNGs at all 4 Apple-required sizes (6.9", 6.5", 6.3", 6.1")
+- Includes a real Next.js starter template plus a bootstrap script
 
 ## Included assets
 
@@ -64,6 +65,30 @@ Or just tell Claude Code what you need:
 
 Claude will ask you about your app's screenshots, brand colors, font, features, style direction, and number of slides before building anything.
 
+## Included starter template
+
+This repo now includes a runnable Next.js starter in `starter/next-app/`.
+It ships with:
+
+- iPhone / iPad device toggle
+- Apple export size presets
+- Per-slide export and export-all flows
+- Offscreen `html-to-image` export wiring
+- Placeholder assets so the page renders before you add your real screenshots
+
+To copy the starter into another folder:
+
+```bash
+node scripts/bootstrap-template.mjs ../my-screenshot-project
+```
+
+Then inside the generated project:
+
+```bash
+bun install
+bun dev
+```
+
 ## Example prompts
 
 These are good starting prompts because they provide product context while still leaving room for the skill to guide the design process.
@@ -110,15 +135,16 @@ Use a soft, warm, organic style and prioritize emotional outcomes over feature l
 
 ## What gets scaffolded
 
-If starting from an empty folder, the skill creates:
+If starting from an empty folder, the skill can now either copy the included starter template or create the same structure from scratch:
 
 ```
 project/
 ├── public/
 │   ├── mockup.png          # iPhone frame (copied from skill)
-│   ├── app-icon.png        # Your app icon
+│   ├── app-icon.svg        # Placeholder app icon (replace with yours)
 │   └── screenshots/        # Your app screenshots
 ├── src/app/
+│   ├── globals.css         # CSS variables and base styles
 │   ├── layout.tsx          # Font setup
 │   └── page.tsx            # Screenshot generator (single file)
 ├── package.json

--- a/scripts/bootstrap-template.mjs
+++ b/scripts/bootstrap-template.mjs
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const sourceRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const templateRoot = path.join(sourceRoot, "starter", "next-app");
+const mockupSource = path.join(
+  sourceRoot,
+  "skills",
+  "app-store-screenshots",
+  "mockup.png",
+);
+
+const targetArg = process.argv[2];
+
+if (!targetArg) {
+  console.error("Usage: node scripts/bootstrap-template.mjs <target-directory>");
+  process.exit(1);
+}
+
+const targetRoot = path.resolve(process.cwd(), targetArg);
+
+function ensureDirectory(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function copyTree(sourceDir, targetDir) {
+  ensureDirectory(targetDir);
+
+  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+
+    if (entry.isDirectory()) {
+      copyTree(sourcePath, targetPath);
+      continue;
+    }
+
+    if (fs.existsSync(targetPath)) {
+      continue;
+    }
+
+    fs.copyFileSync(sourcePath, targetPath);
+  }
+}
+
+copyTree(templateRoot, targetRoot);
+
+ensureDirectory(path.join(targetRoot, "public"));
+ensureDirectory(path.join(targetRoot, "public", "screenshots"));
+ensureDirectory(path.join(targetRoot, "public", "screenshots-ipad"));
+
+const mockupTarget = path.join(targetRoot, "public", "mockup.png");
+if (!fs.existsSync(mockupTarget)) {
+  fs.copyFileSync(mockupSource, mockupTarget);
+}
+
+console.log(`Bootstrapped starter into ${targetRoot}`);
+console.log("Next steps:");
+console.log("  1. Replace placeholder screenshots in public/screenshots/");
+console.log("  2. Optionally add iPad screenshots in public/screenshots-ipad/");
+console.log("  3. Run `bun install` and `bun dev`");

--- a/skills/app-store-screenshots/SKILL.md
+++ b/skills/app-store-screenshots/SKILL.md
@@ -56,7 +56,31 @@ Check what's available, use this priority: **bun > pnpm > yarn > npm**
 which bun && echo "use bun" || which pnpm && echo "use pnpm" || which yarn && echo "use yarn" || echo "use npm"
 ```
 
-### Scaffold (if no existing Next.js project)
+### Preferred bootstrap path
+
+If this skill repo is available locally, prefer copying the included starter template instead of generating every file from scratch:
+
+```bash
+node scripts/bootstrap-template.mjs ./app-store-assets
+```
+
+That starter already includes:
+- a ready-to-run `page.tsx`
+- iPhone / iPad device toggle
+- built-in export buttons
+- placeholder icon + screenshot states
+- `globals.css` with CSS variables
+
+After bootstrapping:
+
+```bash
+cd app-store-assets
+bun install
+```
+
+Then replace the placeholder copy/screenshots and customize the layouts.
+
+### Scaffold (if no existing Next.js project and the starter is unavailable)
 
 ```bash
 # With bun:
@@ -86,7 +110,7 @@ The skill includes a pre-measured iPhone mockup at `mockup.png` (co-located with
 project/
 ├── public/
 │   ├── mockup.png              # iPhone frame (included with skill)
-│   ├── app-icon.png            # User's app icon
+│   ├── app-icon.svg            # Placeholder app icon (replace with user's icon)
 │   ├── screenshots/            # iPhone app screenshots
 │   │   ├── home.png
 │   │   ├── feature-1.png
@@ -96,6 +120,7 @@ project/
 │       ├── feature-1.png
 │       └── ...
 ├── src/app/
+│   ├── globals.css             # CSS variables + base styles
 │   ├── layout.tsx              # Font setup
 │   └── page.tsx                # The screenshot generator (single file)
 └── package.json

--- a/starter/next-app/next-env.d.ts
+++ b/starter/next-app/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// This file is managed by Next.js.

--- a/starter/next-app/next.config.ts
+++ b/starter/next-app/next.config.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { NextConfig } from "next";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+
+const nextConfig: NextConfig = {
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  outputFileTracingRoot: currentDir,
+};
+
+export default nextConfig;

--- a/starter/next-app/package.json
+++ b/starter/next-app/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "app-store-screenshots-starter",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "html-to-image": "^1.11.13",
+    "next": "^15.3.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "typescript": "^5.8.3"
+  }
+}

--- a/starter/next-app/postcss.config.mjs
+++ b/starter/next-app/postcss.config.mjs
@@ -1,0 +1,5 @@
+const config = {
+  plugins: {},
+};
+
+export default config;

--- a/starter/next-app/public/app-icon.svg
+++ b/starter/next-app/public/app-icon.svg
@@ -1,0 +1,11 @@
+<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1024" height="1024" rx="220" fill="url(#bg)" />
+  <rect x="156" y="188" width="712" height="648" rx="140" fill="white" fill-opacity="0.14" />
+  <path d="M318 672L452 352H548L706 672H600L567 584H448L417 672H318ZM478 492H536L509 410L478 492Z" fill="white"/>
+  <defs>
+    <linearGradient id="bg" x1="128" y1="96" x2="864" y2="928" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#60A5FA"/>
+      <stop offset="1" stop-color="#1D4ED8"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/starter/next-app/src/app/globals.css
+++ b/starter/next-app/src/app/globals.css
@@ -1,0 +1,120 @@
+:root {
+  --page-bg: #fafbfc;
+  --surface-primary: #ffffff;
+  --surface-secondary: #f5f7fa;
+  --surface-tertiary: #edf0f5;
+  --surface-inverse: #1a1f36;
+  --surface-glass: rgba(255, 255, 255, 0.72);
+  --surface-glass-border: rgba(0, 0, 0, 0.06);
+
+  --border-default: #e3e8ef;
+  --border-subtle: #edf0f5;
+  --border-strong: #d0d5dd;
+  --border-accent: rgba(55, 114, 255, 0.28);
+
+  --text-primary: #1a1f36;
+  --text-secondary: #4e5d78;
+  --text-tertiary: #8592a6;
+  --text-inverse: #ffffff;
+  --text-accent: #3772ff;
+
+  --accent: #3772ff;
+  --accent-hover: #2860e6;
+  --accent-subtle: rgba(55, 114, 255, 0.08);
+  --accent-soft: rgba(55, 114, 255, 0.14);
+
+  --success: #00b87c;
+  --success-subtle: rgba(0, 184, 124, 0.1);
+
+  --canvas-light-start: #f0f4ff;
+  --canvas-light-end: #e0e8f9;
+  --canvas-dark-start: #0d1117;
+  --canvas-dark-end: #161b22;
+
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.1);
+  --shadow-xl: 0 16px 48px rgba(0, 0, 0, 0.12);
+  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.04), 0 6px 24px rgba(0, 0, 0, 0.06);
+  --shadow-card-hover: 0 2px 8px rgba(0, 0, 0, 0.06), 0 12px 40px rgba(0, 0, 0, 0.1);
+
+  --radius-xs: 8px;
+  --radius-sm: 12px;
+  --radius-md: 16px;
+  --radius-lg: 20px;
+  --radius-xl: 24px;
+  --radius-2xl: 32px;
+  --radius-full: 999px;
+
+  --transition-fast: 120ms cubic-bezier(0.25, 0.1, 0.25, 1);
+  --transition-base: 200ms cubic-bezier(0.25, 0.1, 0.25, 1);
+  --transition-smooth: 320ms cubic-bezier(0.25, 0.1, 0.25, 1);
+
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-mono: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", monospace;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--page-bg);
+  color: var(--text-primary);
+  line-height: 1.5;
+  min-height: 100dvh;
+}
+
+::selection {
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  border: none;
+  background: none;
+  color: inherit;
+}
+
+select {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes shimmer {
+  from { background-position: -200% 0; }
+  to { background-position: 200% 0; }
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}

--- a/starter/next-app/src/app/layout.tsx
+++ b/starter/next-app/src/app/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { Inter } from "next/font/google";
+
+import "./globals.css";
+
+const inter = Inter({
+  subsets: ["latin"],
+});
+
+export const metadata: Metadata = {
+  title: "App Store Screenshot Starter",
+  description: "Starter template for exportable App Store screenshot pages.",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/starter/next-app/src/app/page.tsx
+++ b/starter/next-app/src/app/page.tsx
@@ -1,0 +1,1112 @@
+"use client";
+
+import { toPng } from "html-to-image";
+import type { CSSProperties, ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+type DeviceKind = "iphone" | "ipad";
+
+interface ExportSize {
+  label: string;
+  w: number;
+  h: number;
+}
+
+interface SlideData {
+  slug: string;
+  kicker: string;
+  headline: string;
+  support: string;
+  theme: "light" | "dark";
+  layout: "center" | "offset" | "split";
+}
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+const IPHONE_SIZES: readonly ExportSize[] = [
+  { label: '6.9"', w: 1320, h: 2868 },
+  { label: '6.5"', w: 1284, h: 2778 },
+  { label: '6.3"', w: 1206, h: 2622 },
+  { label: '6.1"', w: 1125, h: 2436 },
+];
+
+const IPAD_SIZES: readonly ExportSize[] = [
+  { label: '13" iPad', w: 2064, h: 2752 },
+  { label: '12.9" iPad Pro', w: 2048, h: 2732 },
+];
+
+const DEVICE_SIZES: Record<DeviceKind, readonly ExportSize[]> = {
+  iphone: IPHONE_SIZES,
+  ipad: IPAD_SIZES,
+};
+
+const SLIDES: readonly SlideData[] = [
+  {
+    slug: "hero",
+    kicker: "HERO BENEFIT",
+    headline: "Turn your best feature\ninto the first thing\npeople feel.",
+    support:
+      "Swap in your real copy, screenshots, and colors. The layout, export flow, and device switching are already wired up.",
+    theme: "light",
+    layout: "center",
+  },
+  {
+    slug: "focus",
+    kicker: "OUTCOME SLIDE",
+    headline: "Sell one clear idea\nper screenshot,\nnot five at once.",
+    support:
+      "Use this slide for one differentiator. Keep the headline short enough to read at thumbnail size.",
+    theme: "dark",
+    layout: "offset",
+  },
+  {
+    slug: "export",
+    kicker: "EXPORT FLOW",
+    headline: "Preview fast.\nExport every size.\nStay production-ready.",
+    support:
+      "The template ships with per-slide export, export-all, numbered filenames, and an iPhone / iPad toggle.",
+    theme: "light",
+    layout: "split",
+  },
+];
+
+const PHONE_MOCKUP = {
+  width: 1022,
+  height: 2082,
+  screenLeft: (52 / 1022) * 100,
+  screenTop: (46 / 2082) * 100,
+  screenWidth: (918 / 1022) * 100,
+  screenHeight: (1990 / 2082) * 100,
+  screenRx: (126 / 918) * 100,
+  screenRy: (126 / 1990) * 100,
+};
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+function downloadDataUrl(dataUrl: string, fileName: string) {
+  const a = document.createElement("a");
+  a.href = dataUrl;
+  a.download = fileName;
+  a.click();
+}
+
+function buildFileName(
+  index: number,
+  slide: SlideData,
+  size: ExportSize,
+  device: DeviceKind,
+) {
+  const pad = String(index + 1).padStart(2, "0");
+  return `${pad}-${device}-${slide.slug}-${size.w}x${size.h}.png`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Hooks                                                              */
+/* ------------------------------------------------------------------ */
+
+function usePreviewScale(targetWidth: number) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width;
+      if (w) setScale(Math.min(w / targetWidth, 1));
+    });
+
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [targetWidth]);
+
+  return { ref, scale };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Primitives                                                         */
+/* ------------------------------------------------------------------ */
+
+function Badge({ children }: { children: ReactNode }) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "6px",
+        padding: "4px 12px",
+        borderRadius: "var(--radius-full)",
+        background: "var(--success-subtle)",
+        color: "var(--success)",
+        fontSize: "12px",
+        fontWeight: 600,
+        letterSpacing: "0.02em",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function Pill({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        padding: "8px 18px",
+        borderRadius: "var(--radius-full)",
+        fontSize: "13px",
+        fontWeight: 600,
+        letterSpacing: "0.01em",
+        background: active ? "var(--text-primary)" : "transparent",
+        color: active ? "var(--text-inverse)" : "var(--text-secondary)",
+        transition: "all var(--transition-fast)",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ActionButton({
+  variant = "primary",
+  disabled,
+  onClick,
+  children,
+}: {
+  variant?: "primary" | "secondary" | "ghost";
+  disabled?: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  const styles: Record<string, CSSProperties> = {
+    primary: {
+      background: "var(--text-primary)",
+      color: "var(--text-inverse)",
+      boxShadow: "var(--shadow-sm)",
+    },
+    secondary: {
+      background: "var(--surface-primary)",
+      color: "var(--text-primary)",
+      border: "1px solid var(--border-default)",
+    },
+    ghost: {
+      background: "transparent",
+      color: "var(--text-secondary)",
+    },
+  };
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      style={{
+        padding: "9px 20px",
+        borderRadius: "var(--radius-full)",
+        fontSize: "13px",
+        fontWeight: 600,
+        transition: "all var(--transition-fast)",
+        opacity: disabled ? 0.5 : 1,
+        cursor: disabled ? "not-allowed" : "pointer",
+        ...styles[variant],
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Screen / Mockup components                                         */
+/* ------------------------------------------------------------------ */
+
+function ScreenPlaceholder({ title }: { title: string }) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "grid",
+        placeItems: "center",
+        padding: "14%",
+        background:
+          "linear-gradient(145deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)",
+        color: "#e2e8f0",
+        textAlign: "center",
+      }}
+    >
+      <div>
+        <div
+          style={{
+            width: "48px",
+            height: "48px",
+            margin: "0 auto 16px",
+            borderRadius: "var(--radius-sm)",
+            background: "rgba(255,255,255,0.08)",
+            display: "grid",
+            placeItems: "center",
+            fontSize: "20px",
+          }}
+        >
+          📱
+        </div>
+        <div
+          style={{
+            fontSize: "1.1rem",
+            fontWeight: 600,
+            lineHeight: 1.3,
+            marginBottom: "8px",
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            fontSize: "0.8rem",
+            color: "rgba(226,232,240,0.5)",
+            lineHeight: 1.4,
+          }}
+        >
+          Drop your screenshot PNG here
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ScreenAsset({ src, fallbackTitle }: { src: string; fallbackTitle: string }) {
+  const [err, setErr] = useState(false);
+
+  if (err) return <ScreenPlaceholder title={fallbackTitle} />;
+
+  return (
+    <img
+      src={src}
+      alt=""
+      draggable={false}
+      onError={() => setErr(true)}
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "block",
+        objectFit: "cover",
+        objectPosition: "top",
+      }}
+    />
+  );
+}
+
+function PhoneMockup({
+  screen,
+  style,
+}: {
+  screen: ReactNode;
+  style?: CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        position: "relative",
+        aspectRatio: `${PHONE_MOCKUP.width}/${PHONE_MOCKUP.height}`,
+        width: "100%",
+        ...style,
+      }}
+    >
+      <img
+        src="/mockup.png"
+        alt=""
+        draggable={false}
+        style={{ width: "100%", height: "100%", display: "block" }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          left: `${PHONE_MOCKUP.screenLeft}%`,
+          top: `${PHONE_MOCKUP.screenTop}%`,
+          width: `${PHONE_MOCKUP.screenWidth}%`,
+          height: `${PHONE_MOCKUP.screenHeight}%`,
+          overflow: "hidden",
+          borderRadius: `${PHONE_MOCKUP.screenRx}% / ${PHONE_MOCKUP.screenRy}%`,
+        }}
+      >
+        {screen}
+      </div>
+    </div>
+  );
+}
+
+function IpadMockup({
+  screen,
+  style,
+}: {
+  screen: ReactNode;
+  style?: CSSProperties;
+}) {
+  return (
+    <div style={{ position: "relative", aspectRatio: "770/1000", width: "100%", ...style }}>
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          position: "relative",
+          overflow: "hidden",
+          borderRadius: "5% / 3.6%",
+          background: "linear-gradient(180deg, #2c2c2e, #1c1c1e)",
+          boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.08), 0 8px 40px rgba(0,0,0,0.42)",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: "1.2%",
+            left: "50%",
+            transform: "translateX(-50%)",
+            width: "0.9%",
+            height: "0.65%",
+            borderRadius: "999px",
+            background: "#09090b",
+            zIndex: 2,
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            left: "4%",
+            top: "2.8%",
+            width: "92%",
+            height: "94.4%",
+            overflow: "hidden",
+            borderRadius: "2.2% / 1.6%",
+            background: "#020617",
+          }}
+        >
+          {screen}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Slide Canvas                                                       */
+/* ------------------------------------------------------------------ */
+
+function SlideCanvas({
+  slide,
+  size,
+  device,
+}: {
+  slide: SlideData;
+  size: ExportSize;
+  device: DeviceKind;
+}) {
+  const screenshotPath =
+    device === "iphone"
+      ? `/screenshots/${slide.slug}.png`
+      : `/screenshots-ipad/${slide.slug}.png`;
+
+  const isLight = slide.theme === "light";
+
+  const vars = {
+    "--s-kicker": isLight ? "#3772ff" : "#93bbff",
+    "--s-text": isLight ? "#0f172a" : "#f8fafc",
+    "--s-support": isLight ? "#475569" : "#94a3b8",
+    "--s-shadow": isLight ? "rgba(15,23,42,0.16)" : "rgba(0,0,0,0.48)",
+    "--s-glow-a": isLight ? "rgba(55,114,255,0.12)" : "rgba(55,114,255,0.2)",
+    "--s-glow-b": isLight ? "rgba(14,165,233,0.08)" : "rgba(14,165,233,0.16)",
+  } as CSSProperties;
+
+  function renderFrame() {
+    const screen = (
+      <ScreenAsset src={screenshotPath} fallbackTitle={slide.kicker} />
+    );
+    const isSplit = slide.layout === "split";
+
+    return device === "iphone" ? (
+      <PhoneMockup screen={screen} style={{ width: isSplit ? "54%" : "72%" }} />
+    ) : (
+      <IpadMockup screen={screen} style={{ width: isSplit ? "52%" : "64%" }} />
+    );
+  }
+
+  return (
+    <div
+      style={{
+        ...vars,
+        width: size.w,
+        height: size.h,
+        position: "relative",
+        overflow: "hidden",
+        background: isLight
+          ? "linear-gradient(165deg, var(--canvas-light-start), var(--canvas-light-end))"
+          : "linear-gradient(165deg, var(--canvas-dark-start), var(--canvas-dark-end))",
+      }}
+    >
+      {/* Decorative glow orbs */}
+      <div
+        style={{
+          position: "absolute",
+          top: "-14%",
+          right: "-8%",
+          width: "42%",
+          aspectRatio: "1",
+          borderRadius: "999px",
+          background: "var(--s-glow-a)",
+          filter: "blur(80px)",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          bottom: "-10%",
+          left: "-8%",
+          width: "34%",
+          aspectRatio: "1",
+          borderRadius: "999px",
+          background: "var(--s-glow-b)",
+          filter: "blur(60px)",
+        }}
+      />
+
+      {/* Copy block */}
+      <div
+        style={{
+          position: "absolute",
+          left: "8%",
+          top: "7%",
+          width: "42%",
+          zIndex: 2,
+        }}
+      >
+        <div
+          style={{
+            color: "var(--s-kicker)",
+            fontSize: size.w * 0.022,
+            fontWeight: 700,
+            letterSpacing: "0.14em",
+            marginBottom: size.w * 0.02,
+          }}
+        >
+          {slide.kicker}
+        </div>
+        <h1
+          style={{
+            margin: 0,
+            whiteSpace: "pre-line",
+            color: "var(--s-text)",
+            fontSize: size.w * (device === "iphone" ? 0.068 : 0.058),
+            fontWeight: 700,
+            lineHeight: 1.0,
+            letterSpacing: "-0.035em",
+          }}
+        >
+          {slide.headline}
+        </h1>
+        <p
+          style={{
+            margin: `${size.w * 0.028}px 0 0`,
+            color: "var(--s-support)",
+            fontSize: size.w * 0.022,
+            lineHeight: 1.5,
+            maxWidth: "92%",
+          }}
+        >
+          {slide.support}
+        </p>
+      </div>
+
+      {/* Device placement */}
+      {slide.layout === "center" && (
+        <div
+          style={{
+            position: "absolute",
+            left: "50%",
+            bottom: "-4%",
+            transform: "translateX(-50%)",
+            width: device === "iphone" ? "80%" : "72%",
+            filter: "drop-shadow(0 24px 48px var(--s-shadow))",
+          }}
+        >
+          {renderFrame()}
+        </div>
+      )}
+
+      {slide.layout === "offset" && (
+        <div
+          style={{
+            position: "absolute",
+            right: device === "iphone" ? "-1%" : "4%",
+            bottom: "-2%",
+            width: device === "iphone" ? "68%" : "64%",
+            transform: "rotate(-4deg)",
+            filter: "drop-shadow(0 24px 48px var(--s-shadow))",
+          }}
+        >
+          {renderFrame()}
+        </div>
+      )}
+
+      {slide.layout === "split" && (
+        <>
+          <div
+            style={{
+              position: "absolute",
+              left: device === "iphone" ? "-3%" : "5%",
+              bottom: "5%",
+              width: device === "iphone" ? "48%" : "40%",
+              opacity: 0.65,
+              transform: "rotate(-8deg)",
+              filter: "drop-shadow(0 20px 42px var(--s-shadow))",
+            }}
+          >
+            {renderFrame()}
+          </div>
+          <div
+            style={{
+              position: "absolute",
+              right: device === "iphone" ? "3%" : "9%",
+              bottom: "-1%",
+              width: device === "iphone" ? "54%" : "44%",
+              filter: "drop-shadow(0 24px 48px var(--s-shadow))",
+            }}
+          >
+            {renderFrame()}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Preview Card                                                       */
+/* ------------------------------------------------------------------ */
+
+function PreviewCard({
+  slide,
+  size,
+  device,
+  index,
+  onExport,
+}: {
+  slide: SlideData;
+  size: ExportSize;
+  device: DeviceKind;
+  index: number;
+  onExport: () => void;
+}) {
+  const { ref, scale } = usePreviewScale(size.w);
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        borderRadius: "var(--radius-xl)",
+        border: `1px solid ${hovered ? "var(--border-accent)" : "var(--border-default)"}`,
+        background: "var(--surface-primary)",
+        boxShadow: hovered ? "var(--shadow-card-hover)" : "var(--shadow-card)",
+        transition: "all var(--transition-smooth)",
+        overflow: "hidden",
+        animation: "fadeIn 400ms ease both",
+        animationDelay: `${index * 80}ms`,
+      }}
+    >
+      {/* Preview area */}
+      <div
+        ref={ref}
+        style={{
+          width: "100%",
+          height: size.h * scale,
+          position: "relative",
+          overflow: "hidden",
+          borderRadius: "var(--radius-lg) var(--radius-lg) 0 0",
+          background: "var(--surface-secondary)",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            width: size.w,
+            height: size.h,
+            transform: `scale(${scale})`,
+            transformOrigin: "top left",
+          }}
+        >
+          <SlideCanvas slide={slide} size={size} device={device} />
+        </div>
+      </div>
+
+      {/* Card footer */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "16px 20px",
+          borderTop: "1px solid var(--border-subtle)",
+        }}
+      >
+        <div>
+          <div
+            style={{
+              fontSize: "14px",
+              fontWeight: 600,
+              color: "var(--text-primary)",
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+            }}
+          >
+            <span
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: "22px",
+                height: "22px",
+                borderRadius: "var(--radius-full)",
+                background: "var(--accent-subtle)",
+                color: "var(--text-accent)",
+                fontSize: "11px",
+                fontWeight: 700,
+              }}
+            >
+              {index + 1}
+            </span>
+            {slide.slug}
+          </div>
+          <div
+            style={{
+              fontSize: "12px",
+              color: "var(--text-tertiary)",
+              marginTop: "2px",
+              fontFamily: "var(--font-mono)",
+            }}
+          >
+            {size.w} × {size.h} · {slide.theme}
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={onExport}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "6px",
+            padding: "7px 14px",
+            borderRadius: "var(--radius-full)",
+            background: hovered ? "var(--text-primary)" : "var(--surface-secondary)",
+            color: hovered ? "var(--text-inverse)" : "var(--text-secondary)",
+            fontSize: "12px",
+            fontWeight: 600,
+            transition: "all var(--transition-fast)",
+            border: hovered ? "none" : "1px solid var(--border-default)",
+          }}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            style={{ flexShrink: 0 }}
+          >
+            <path
+              d="M6 1.5v7M3 6.5l3 3 3-3M2 10.5h8"
+              stroke="currentColor"
+              strokeWidth="1.25"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          Export
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                               */
+/* ------------------------------------------------------------------ */
+
+export default function HomePage() {
+  const [device, setDevice] = useState<DeviceKind>("iphone");
+  const [sizeIndex, setSizeIndex] = useState(0);
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportedCount, setExportedCount] = useState(0);
+  const exportRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  useEffect(() => {
+    const params = new URL(window.location.href).searchParams;
+    if (params.get("device") === "ipad") setDevice("ipad");
+  }, []);
+
+  const sizes = DEVICE_SIZES[device];
+  const selectedSize = sizes[sizeIndex] ?? sizes[0];
+
+  const registryKey = useMemo(
+    () => `${device}-${selectedSize.w}x${selectedSize.h}`,
+    [device, selectedSize.w, selectedSize.h],
+  );
+
+  useEffect(() => {
+    setSizeIndex(0);
+  }, [device]);
+
+  const doExport = useCallback(
+    async (slide: SlideData, index: number) => {
+      const key = `${registryKey}-${slide.slug}`;
+      const el = exportRefs.current[key];
+      if (!el) return;
+
+      const opts = {
+        width: selectedSize.w,
+        height: selectedSize.h,
+        pixelRatio: 1,
+        cacheBust: true,
+      };
+
+      await toPng(el, opts);
+      const dataUrl = await toPng(el, opts);
+      downloadDataUrl(dataUrl, buildFileName(index, slide, selectedSize, device));
+    },
+    [registryKey, selectedSize, device],
+  );
+
+  async function handleExportAll() {
+    setIsExporting(true);
+    setExportedCount(0);
+    try {
+      for (const [i, slide] of SLIDES.entries()) {
+        await doExport(slide, i);
+        setExportedCount(i + 1);
+        await wait(300);
+      }
+    } finally {
+      setIsExporting(false);
+      setTimeout(() => setExportedCount(0), 2000);
+    }
+  }
+
+  return (
+    <main style={{ minHeight: "100dvh" }}>
+      {/* ---- Top bar ---- */}
+      <header
+        style={{
+          position: "sticky",
+          top: 0,
+          zIndex: 50,
+          background: "var(--surface-glass)",
+          backdropFilter: "blur(16px) saturate(1.6)",
+          WebkitBackdropFilter: "blur(16px) saturate(1.6)",
+          borderBottom: "1px solid var(--surface-glass-border)",
+        }}
+      >
+        <div
+          style={{
+            maxWidth: "1440px",
+            margin: "0 auto",
+            padding: "14px 28px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "16px",
+            flexWrap: "wrap",
+          }}
+        >
+          {/* Left: brand */}
+          <div style={{ display: "flex", alignItems: "center", gap: "14px" }}>
+            <div
+              style={{
+                width: "36px",
+                height: "36px",
+                borderRadius: "var(--radius-sm)",
+                background: "linear-gradient(135deg, #3772ff, #1d4ed8)",
+                display: "grid",
+                placeItems: "center",
+                color: "white",
+                fontWeight: 800,
+                fontSize: "16px",
+                boxShadow: "0 2px 8px rgba(55,114,255,0.3)",
+              }}
+            >
+              S
+            </div>
+            <div>
+              <div
+                style={{
+                  fontSize: "15px",
+                  fontWeight: 700,
+                  letterSpacing: "-0.02em",
+                  color: "var(--text-primary)",
+                }}
+              >
+                Screenshot Studio
+              </div>
+              <div
+                style={{
+                  fontSize: "12px",
+                  color: "var(--text-tertiary)",
+                }}
+              >
+                {SLIDES.length} slides · {device === "iphone" ? "iPhone" : "iPad"} · {selectedSize.label}
+              </div>
+            </div>
+          </div>
+
+          {/* Center: controls */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+              flexWrap: "wrap",
+            }}
+          >
+            {/* Device toggle */}
+            <div
+              style={{
+                display: "inline-flex",
+                padding: "3px",
+                borderRadius: "var(--radius-full)",
+                background: "var(--surface-secondary)",
+                border: "1px solid var(--border-subtle)",
+              }}
+            >
+              <Pill
+                active={device === "iphone"}
+                onClick={() => setDevice("iphone")}
+              >
+                iPhone
+              </Pill>
+              <Pill
+                active={device === "ipad"}
+                onClick={() => setDevice("ipad")}
+              >
+                iPad
+              </Pill>
+            </div>
+
+            {/* Size select */}
+            <select
+              value={sizeIndex}
+              onChange={(e) => setSizeIndex(Number(e.target.value))}
+              style={{
+                padding: "8px 36px 8px 14px",
+                borderRadius: "var(--radius-full)",
+                border: "1px solid var(--border-default)",
+                background: "var(--surface-primary)",
+                color: "var(--text-primary)",
+                fontSize: "13px",
+                fontWeight: 500,
+                appearance: "none",
+                backgroundImage:
+                  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' fill='none'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%234e5d78' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E\")",
+                backgroundRepeat: "no-repeat",
+                backgroundPosition: "right 12px center",
+              }}
+            >
+              {sizes.map((s, i) => (
+                <option key={`${s.w}-${s.h}`} value={i}>
+                  {s.label} · {s.w}×{s.h}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Right: actions */}
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            {isExporting && (
+              <Badge>
+                <span style={{ animation: "pulse 1s infinite" }}>●</span>
+                {exportedCount}/{SLIDES.length}
+              </Badge>
+            )}
+            <ActionButton
+              variant="secondary"
+              disabled={isExporting}
+              onClick={() => void handleExportAll()}
+            >
+              {isExporting ? "Exporting..." : "Export all"}
+            </ActionButton>
+          </div>
+        </div>
+      </header>
+
+      {/* ---- Hero section ---- */}
+      <section
+        style={{
+          maxWidth: "1440px",
+          margin: "0 auto",
+          padding: "48px 28px 20px",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "start",
+            justifyContent: "space-between",
+            gap: "24px",
+            flexWrap: "wrap",
+          }}
+        >
+          <div>
+            <h1
+              style={{
+                fontSize: "clamp(1.8rem, 3.5vw, 2.8rem)",
+                fontWeight: 750,
+                lineHeight: 1.08,
+                letterSpacing: "-0.04em",
+                color: "var(--text-primary)",
+              }}
+            >
+              Build once.
+              <br />
+              Export every size.
+            </h1>
+            <p
+              style={{
+                marginTop: "12px",
+                maxWidth: "520px",
+                color: "var(--text-secondary)",
+                fontSize: "15px",
+                lineHeight: 1.6,
+              }}
+            >
+              Replace the placeholder copy and screenshot files, then use the
+              controls above to export production-sized App Store assets.
+            </p>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              gap: "12px",
+              flexWrap: "wrap",
+            }}
+          >
+            {[
+              { label: "Slides", value: String(SLIDES.length) },
+              { label: "Sizes", value: String(sizes.length) },
+              {
+                label: "Total exports",
+                value: String(SLIDES.length * sizes.length),
+              },
+            ].map((stat) => (
+              <div
+                key={stat.label}
+                style={{
+                  padding: "16px 24px",
+                  borderRadius: "var(--radius-lg)",
+                  border: "1px solid var(--border-default)",
+                  background: "var(--surface-primary)",
+                  minWidth: "100px",
+                  textAlign: "center",
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: "24px",
+                    fontWeight: 700,
+                    letterSpacing: "-0.03em",
+                    color: "var(--text-primary)",
+                  }}
+                >
+                  {stat.value}
+                </div>
+                <div
+                  style={{
+                    fontSize: "12px",
+                    color: "var(--text-tertiary)",
+                    marginTop: "2px",
+                  }}
+                >
+                  {stat.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ---- Grid ---- */}
+      <section
+        style={{
+          maxWidth: "1440px",
+          margin: "0 auto",
+          padding: "20px 28px 80px",
+          display: "grid",
+          gap: "20px",
+          gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))",
+        }}
+      >
+        {SLIDES.map((slide, index) => (
+          <PreviewCard
+            key={`${device}-${selectedSize.w}-${slide.slug}`}
+            slide={slide}
+            size={selectedSize}
+            device={device}
+            index={index}
+            onExport={() => void doExport(slide, index)}
+          />
+        ))}
+      </section>
+
+      {/* ---- Offscreen export targets ---- */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          left: "-9999px",
+          top: 0,
+          pointerEvents: "none",
+          opacity: 0,
+        }}
+      >
+        {SLIDES.map((slide) => {
+          const key = `${registryKey}-${slide.slug}`;
+          return (
+            <div
+              key={key}
+              ref={(node) => {
+                exportRefs.current[key] = node;
+              }}
+            >
+              <SlideCanvas slide={slide} size={selectedSize} device={device} />
+            </div>
+          );
+        })}
+      </div>
+    </main>
+  );
+}

--- a/starter/next-app/tsconfig.json
+++ b/starter/next-app/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Adds a complete, runnable Next.js starter template under `starter/next-app/` and a bootstrap script to copy it into any project. Users no longer need to generate the entire screenshot page from scratch — they can start from a working, professionally designed template.

## What's included

### `starter/next-app/` — Ready-to-run screenshot generator

- **`page.tsx`** (~1100 lines): Full screenshot studio with:
  - iPhone / iPad device toggle
  - All Apple-required export size presets (6.9", 6.5", 6.3", 6.1" iPhone + 13" and 12.9" iPad)
  - Per-slide export and batch "Export all" with progress indicator
  - ResizeObserver-based preview scaling that fits any viewport
  - Offscreen render targets with the double-call `html-to-image` trick
  - Numbered filename output (`01-iphone-hero-1320x2868.png`)
  - `?device=ipad` URL parameter for headless/automated capture
  - Graceful fallback placeholders when screenshot PNGs are missing
  - Three layout variants (center, offset, split) with light/dark themes

- **`globals.css`**: Design-system-grade CSS variables — colors, shadows, radii, transitions, typography — with a clean, professional aesthetic

- **`layout.tsx`**: Inter font setup with proper metadata

- **`package.json`**: Minimal dependencies (Next.js 15, React 19, html-to-image, TypeScript)

- **`public/app-icon.svg`**: Placeholder app icon

### `scripts/bootstrap-template.mjs` — One-command setup

```bash
node scripts/bootstrap-template.mjs ./my-screenshots
cd my-screenshots && bun install && bun dev
```

- Copies the starter tree into a target directory (skip-if-exists for safe re-runs)
- Creates `public/screenshots/` and `public/screenshots-ipad/` directories
- Copies `mockup.png` from the skill assets into `public/`

### Updated docs

- **README.md**: Documents the new starter and bootstrap workflow
- **SKILL.md**: Adds a "preferred bootstrap path" section so AI agents use the template first

## Design highlights

- Sticky frosted-glass header with backdrop blur
- Wise/Linear-inspired color palette and typography
- Hover-activated card borders and shadow transitions
- Animated card entrance (staggered fadeIn)
- Export progress badge with pulse animation
- Stat cards showing slide count, sizes, and total exports
- Fully responsive grid layout
- CSS custom properties throughout (zero hardcoded colors)

## Testing

- `bun install` + `bun run build`: passes cleanly on a fresh bootstrap
- `bun dev`: serves correctly at `localhost:3000`
- Verified HTML output contains all expected components

