### PR TITLE
Add theme presets, RTL guidance, and bulk locale exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ A skill for AI-powered coding agents (Claude Code, Cursor, Windsurf, etc.) that 
 - Writes compelling copy using proven App Store copywriting patterns
 - Renders screenshots at full resolution with a built-in iPhone mockup
 - Exports PNGs at all 4 Apple-required sizes (6.9", 6.5", 6.3", 6.1")
+- Supports locale-based screenshot sets and localized copy
+- Supports reusable theme presets so you can swap art direction quickly
+- Supports RTL-aware layouts and bulk export across locale/device/theme combinations
 
 ## Included assets
 
@@ -100,12 +103,23 @@ The app focuses on sleep, stress relief, and short guided sessions.
 Use a soft, warm, organic style and prioritize emotional outcomes over feature lists.
 ```
 
+### Multi-language / multi-theme
+
+```text
+Build App Store screenshots for my language learning app.
+I need English, German, and Arabic screenshot sets.
+Use two reusable themes: clean-light and dark-bold.
+Make sure Arabic slides feel RTL-native, not just translated.
+```
+
 ## Better prompt tips
 
 - say what the app does in one sentence
 - list the top 3-5 features in priority order
 - describe the visual style you want
 - mention how many slides you need
+- mention if you need multiple languages or RTL locales
+- mention if you want one art direction or reusable theme presets
 - provide references if you want the output to match a certain App Store style
 
 ## What gets scaffolded
@@ -117,7 +131,8 @@ project/
 ├── public/
 │   ├── mockup.png          # iPhone frame (copied from skill)
 │   ├── app-icon.png        # Your app icon
-│   └── screenshots/        # Your app screenshots
+│   ├── screenshots/        # Your app screenshots (locale folders optional)
+│   └── screenshots-ipad/   # Optional iPad screenshots (locale folders optional)
 ├── src/app/
 │   ├── layout.tsx          # Font setup
 │   └── page.tsx            # Screenshot generator (single file)
@@ -126,6 +141,13 @@ project/
 ```
 
 The entire generator is a **single `page.tsx` file**. Run the dev server, open the browser, click any screenshot to export it as a PNG.
+
+The latest version of the skill also guides the agent to generate:
+
+- locale tabs and locale-specific screenshot folders
+- reusable theme presets backed by design tokens
+- RTL-aware layouts for languages like Arabic and Hebrew
+- bulk export flows for locale/device/theme combinations
 
 ## Export sizes
 
@@ -137,6 +159,51 @@ The entire generator is a **single `page.tsx` file**. Run the dev server, open t
 | 6.1" | 1125 x 2436 |
 
 Screenshots are designed at 1320x2868 (largest) and scaled down for smaller sizes.
+
+## Advanced capabilities
+
+### Multi-language screenshots
+
+The skill can generate screenshot systems for multiple locales by nesting images under locale folders such as:
+
+```text
+public/screenshots/en/home.png
+public/screenshots/de/home.png
+public/screenshots/ar/home.png
+```
+
+The generated page keeps slide structure the same and swaps only the locale base path and copy dictionary.
+
+### Theme presets
+
+Instead of hardcoding one art direction, the skill now encourages a token-driven preset system, for example:
+
+```ts
+const THEMES = {
+  "clean-light": { bg: "#F6F1EA", fg: "#171717", accent: "#5B7CFA" },
+  "dark-bold": { bg: "#0B1020", fg: "#F8FAFC", accent: "#8B5CF6" },
+  "warm-editorial": { bg: "#F7E8DA", fg: "#2B1D17", accent: "#D97706" },
+} as const;
+```
+
+This lets you reuse the same slide system while testing different visual directions fast.
+
+### RTL-aware design
+
+For RTL locales such as Arabic and Hebrew, the skill now tells the agent to:
+
+- set `dir="rtl"` on the screenshot canvas
+- rewrite line breaks for the target language
+- mirror asymmetric layouts intentionally
+- keep the composition feeling native instead of mechanically flipped
+
+### Bulk export matrix
+
+The generator is now expected to support exporting not only the current slide, but also:
+
+- all slides for the current locale/device/theme
+- all locales for the current theme
+- full locale + device + theme matrices when needed
 
 ## Tech stack
 

--- a/skills/app-store-screenshots/SKILL.md
+++ b/skills/app-store-screenshots/SKILL.md
@@ -31,8 +31,9 @@ Before writing ANY code, ask the user all of these. Do not proceed until you hav
 
 8. **iPad screenshots** — "Do you also have iPad screenshots? If so, we'll generate iPad App Store screenshots too (recommended for universal apps)."
 9. **Component assets** — "Do you have any UI element PNGs (cards, widgets, etc.) you want as floating decorations? If not, that's fine — we'll skip them."
-10. **Localized screenshots** — "Do you want screenshots in multiple languages? This helps your listing rank in regional App Stores even if your app is English-only. If yes: which languages? (e.g. en, de, es, pt, ja)"
-11. **Additional instructions** — "Any specific requirements, constraints, or preferences?"
+10. **Localized screenshots** — "Do you want screenshots in multiple languages? This helps your listing rank in regional App Stores even if your app is English-only. If yes: which languages? (e.g. en, de, es, pt, ja, ar, he)"
+11. **Theme preset system** — "Do you want one art direction, or reusable visual themes (for example: clean-light, dark-bold, warm-editorial) so you can swap screenshot looks quickly?"
+12. **Additional instructions** — "Any specific requirements, constraints, or preferences?"
 
 ### Derived from answers (do NOT ask — decide yourself)
 
@@ -42,6 +43,8 @@ Based on the user's style direction, brand colors, and app aesthetic, decide:
 - **Dark vs light slides**: how many of each, which features suit dark treatment
 - **Typography treatment**: weight, tracking, line height — match the brand personality
 - **Color palette**: derive text colors, secondary colors, shadow tints from the brand colors
+- **Theme preset names**: turn vague style requests into reusable theme ids the user can switch between
+- **RTL behavior**: if any locale is RTL (`ar`, `he`, `fa`, `ur`), mirror layout intentionally instead of just translating the text
 
 **IMPORTANT:** If the user gives additional instructions at any point during the process, follow them. User instructions always override skill defaults.
 
@@ -116,6 +119,15 @@ project/
     └── {locale}/
 ```
 
+If iPad screenshots are localized too, mirror the same locale structure:
+
+```
+└── screenshots-ipad/
+    ├── en/
+    ├── de/
+    └── {locale}/
+```
+
 **The entire generator is a single `page.tsx` file.** No routing, no extra layouts, no API routes.
 
 ### Multi-language: Locale Tabs
@@ -140,6 +152,61 @@ const base = `/screenshots/${locale}`;
 
 // In every slide — unchanged between single and multi-language:
 <Phone src={`${base}/home.png`} alt="Home" />
+```
+
+### Theme Presets + Locale Metadata
+
+Add a small config layer so the user can switch theme and locale without rewriting slide components:
+
+```tsx
+const LOCALES = ["en", "de", "ar"] as const;
+type Locale = typeof LOCALES[number];
+
+const RTL_LOCALES = new Set<Locale>(["ar"]);
+
+const THEMES = {
+  "clean-light": {
+    bg: "#F6F1EA",
+    fg: "#171717",
+    accent: "#5B7CFA",
+    muted: "#6B7280",
+  },
+  "dark-bold": {
+    bg: "#0B1020",
+    fg: "#F8FAFC",
+    accent: "#8B5CF6",
+    muted: "#94A3B8",
+  },
+  "warm-editorial": {
+    bg: "#F7E8DA",
+    fg: "#2B1D17",
+    accent: "#D97706",
+    muted: "#7C5A47",
+  },
+} as const;
+
+type ThemeId = keyof typeof THEMES;
+
+const COPY_BY_LOCALE = {
+  en: { hero: "Build better habits" },
+  de: { hero: "Baue bessere Gewohnheiten auf" },
+  ar: { hero: "ابنِ عادات أفضل" },
+} satisfies Record<Locale, { hero: string }>;
+
+const [themeId, setThemeId] = useState<ThemeId>("clean-light");
+const [locale, setLocale] = useState<Locale>("en");
+
+const theme = THEMES[themeId];
+const copy = COPY_BY_LOCALE[locale];
+const isRtl = RTL_LOCALES.has(locale);
+```
+
+Use theme tokens everywhere instead of hardcoding colors. For RTL locales, set `dir={isRtl ? "rtl" : "ltr"}` on the screenshot canvas and mirror asymmetric layouts intentionally.
+
+Support query params for automation:
+
+```tsx
+// ?locale=de&theme=dark-bold&device=ipad
 ```
 
 ### Font Setup
@@ -249,6 +316,13 @@ The pattern is:
 3. desired slide count
 4. style direction
 
+### Localization Rules
+
+- Do not literally translate headlines if the result becomes long or awkward.
+- Re-write copy for the target market while keeping the same selling idea.
+- Re-check line breaks per locale; German, French, and Portuguese often need shorter claims.
+- For RTL languages, also reverse badge alignment, supporting decorations, and phone offsets when the composition depends on left/right weight.
+
 ### Reference Apps for Copy Style
 
 - **Raycast** — specific, descriptive, one concrete value per slide
@@ -262,6 +336,7 @@ The pattern is:
 ```
 page.tsx
 ├── Constants (IPHONE_W/H, IPAD_W/H, SIZES, design tokens)
+├── LOCALES / RTL_LOCALES / THEMES / COPY_BY_LOCALE
 ├── Phone component (mockup PNG with screen overlay)
 ├── IPad component (CSS-only frame with screen overlay)
 ├── Caption component (label + headline, accepts canvasW for scaling)
@@ -270,7 +345,7 @@ page.tsx
 ├── iPadSlide1..N components (same designs, adjusted for iPad proportions)
 ├── IPHONE_SCREENSHOTS / IPAD_SCREENSHOTS arrays (registries)
 ├── ScreenshotPreview (ResizeObserver scaling + hover export)
-└── ScreenshotsPage (grid + device toggle + size dropdown + export logic)
+└── ScreenshotsPage (grid + locale tabs + theme tabs + device toggle + export logic)
 ```
 
 ### Export Sizes (Apple Required, portrait)
@@ -304,6 +379,15 @@ Design iPad slides at 2064x2752 and scale down. iPad screenshots are optional bu
 #### Device Toggle
 
 When supporting both devices, add a toggle (iPhone / iPad) in the toolbar next to the size dropdown. The size dropdown should switch between iPhone and iPad sizes based on the selected device. Support a `?device=ipad` URL parameter for headless/automated capture workflows.
+
+#### Theme + Locale Toggles
+
+Place locale and theme selectors in the same toolbar as device + size. This turns the generator into a small control panel instead of a one-off page.
+
+- `locale` switches screenshot folders and copy dictionaries
+- `theme` switches design tokens only
+- `device` switches iPhone/iPad slide registries
+- `size` switches export resolution only
 
 ### Rendering Strategy
 
@@ -470,6 +554,40 @@ el.style.opacity = "";
 el.style.zIndex = "";
 ```
 
+### Export Matrix
+
+If the project supports multiple locales and themes, add bulk export helpers so the user can export everything in one pass:
+
+```typescript
+const jobs = LOCALES.flatMap(locale =>
+  ACTIVE_THEME_IDS.flatMap(themeId =>
+    ACTIVE_DEVICES.flatMap(device =>
+      getSlidesFor(device).map((slide, index) => ({
+        locale,
+        themeId,
+        device,
+        index,
+        slide,
+      })),
+    ),
+  ),
+);
+```
+
+Name files so they sort cleanly and preserve metadata:
+
+```text
+01-hero-en-clean-light-iphone-1320x2868.png
+01-hero-ar-dark-bold-ipad-2064x2752.png
+```
+
+At minimum, support:
+
+1. export current slide
+2. export all slides for current locale/device/theme
+3. export all locales for current theme
+4. export full matrix when the user explicitly asks for it
+
 ### Key Rules
 
 - **Double-call trick**: First `toPng()` loads fonts/images lazily. Second produces clean output. Without this, exports are blank.
@@ -501,6 +619,9 @@ Before handing the page back to the user, review every slide against this checkl
 - **No clipped text or assets** after scaling to the selected export size
 - **Screenshots are correctly aligned** inside the phone or iPad frame
 - **Filenames sort correctly** with zero-padded numeric prefixes
+- **Theme tokens are applied consistently** across all slides in the same preset
+- **Localized copy still fits** after translation, especially on long-word languages
+- **RTL slides feel designed, not just flipped**
 
 ### Hand-off Behavior
 


### PR DESCRIPTION
## Summary
- expand the skill to support reusable theme presets, locale metadata, and RTL-aware screenshot layouts
- document multi-locale iPad folder structure plus toolbar controls for locale/theme/device switching
- add bulk export matrix guidance for locale, device, and theme combinations, and update the README with these new capabilities

## Test plan
- reviewed the updated `README.md` and `skills/app-store-screenshots/SKILL.md` content for consistency
- verified the repo has no linter diagnostics for the edited files in the workspace
