### PR TITLE
Set background color to white in screenshot editor

### DIFF
--- a/skills/app-store-screenshots/template/src/components/editor/screenshot-editor.tsx
+++ b/skills/app-store-screenshots/template/src/components/editor/screenshot-editor.tsx
@@ -393,6 +393,7 @@ export function ScreenshotEditor() {
         height: h,
         pixelRatio: 1,
         cacheBust: false,
+        backgroundColor: "#ffffff",
       });
       return dataUrl;
     } finally {


### PR DESCRIPTION
without this app store connect was complaining during import that images with alpha and transparency aren't allowed.

## Summary

fixes app store connect import error `"Images can't contain alpha channels or transparencies." `

## Validation

tested by exporting with this update and importing to app store connect without errors.

## Checklist

- [x] I checked open PRs/issues for overlap
- [x] I kept `README.md` and `SKILL.md` aligned where needed
- [x] I tested the changed workflow or documented why testing was not possible
