### PR TITLE
Add per-slide typography scale controls

### DIFF
--- a/skills/app-store-screenshots/template/src/components/editor/inspector.tsx
+++ b/skills/app-store-screenshots/template/src/components/editor/inspector.tsx
@@ -33,6 +33,12 @@ import {
   toTextElementId,
 } from "@/lib/elements";
 import { pickText, writeLocalized } from "@/lib/locale";
+import {
+  cleanTypography,
+  FONT_SCALE_MAX,
+  FONT_SCALE_MIN,
+  slideFontScales,
+} from "@/lib/typography";
 import type {
   BuiltInElementId,
   Device,
@@ -41,6 +47,7 @@ import type {
   Orientation,
   Slide,
   SlideLayout,
+  SlideTypography,
   TextElement,
 } from "@/lib/types";
 import { ScreenshotPicker } from "./screenshot-picker";
@@ -160,6 +167,8 @@ export function Inspector({
             placeholder={headlinePlaceholder}
           />
         </div>
+
+        <TypographySection slide={slide} isFeatureGraphic={isFeatureGraphic} onChange={onChange} />
 
         {!isFeatureGraphic && !isNoDevice && (
           <div className="space-y-1.5">
@@ -524,7 +533,22 @@ function TextElementPanel({
       </div>
       <div className="grid grid-cols-[1fr_76px] gap-2">
         <div className="space-y-1">
-          <Label className="text-[11px] text-muted-foreground">Size</Label>
+          <div className="flex items-center justify-between">
+            <Label className="text-[11px] text-muted-foreground">Size</Label>
+            <span className="text-[11px] tabular-nums text-muted-foreground">
+              {Math.round(element.fontSize || 72)}px
+            </span>
+          </div>
+          <input
+            type="range"
+            min={12}
+            max={400}
+            step={1}
+            value={Math.round(element.fontSize || 72)}
+            onChange={(event) => onTextPatch({ fontSize: Number(event.target.value) || 72 })}
+            className="w-full"
+            aria-label="Text size"
+          />
           <Input
             type="number"
             min={12}
@@ -594,6 +618,98 @@ function LayerButton({
     >
       {children}
     </Button>
+  );
+}
+
+function TypographySection({
+  slide,
+  isFeatureGraphic,
+  onChange,
+}: {
+  slide: Slide;
+  isFeatureGraphic: boolean;
+  onChange: (patch: Partial<Slide>) => void;
+}) {
+  const scales = slideFontScales(slide);
+
+  function patchTypography(patch: Partial<SlideTypography>) {
+    onChange({
+      typography: cleanTypography({ ...slide.typography, ...patch }),
+    });
+  }
+
+  return (
+    <div className="space-y-3 rounded-md border bg-muted/20 p-3">
+      <div>
+        <Label className="text-xs font-semibold">Typography</Label>
+        <p className="text-[11px] text-muted-foreground">
+          Relative to the layout default (100%). Applies to this screen only.
+        </p>
+      </div>
+      {!isFeatureGraphic && (
+        <FontScaleSlider
+          label="Label"
+          value={scales.labelScale}
+          onChange={(value) => patchTypography({ labelScale: value })}
+        />
+      )}
+      <FontScaleSlider
+        label={isFeatureGraphic ? "Tagline" : "Headline"}
+        value={scales.headlineScale}
+        onChange={(value) => patchTypography({ headlineScale: value })}
+      />
+      {isFeatureGraphic && (
+        <FontScaleSlider
+          label="App name"
+          value={scales.appNameScale}
+          onChange={(value) => patchTypography({ appNameScale: value })}
+        />
+      )}
+    </div>
+  );
+}
+
+function FontScaleSlider({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+}) {
+  const pct = Math.round(value * 100);
+  const minPct = Math.round(FONT_SCALE_MIN * 100);
+  const maxPct = Math.round(FONT_SCALE_MAX * 100);
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <Label className="text-[11px] text-muted-foreground">{label}</Label>
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] tabular-nums text-muted-foreground">{pct}%</span>
+          {pct !== 100 ? (
+            <button
+              type="button"
+              className="text-[10px] text-muted-foreground underline-offset-2 hover:underline"
+              onClick={() => onChange(1)}
+            >
+              Reset
+            </button>
+          ) : null}
+        </div>
+      </div>
+      <input
+        type="range"
+        min={minPct}
+        max={maxPct}
+        step={5}
+        value={pct}
+        onChange={(event) => onChange(Number(event.target.value) / 100)}
+        className="w-full"
+        aria-label={`${label} font size`}
+      />
+    </div>
   );
 }
 

--- a/skills/app-store-screenshots/template/src/components/editor/slide-canvas.tsx
+++ b/skills/app-store-screenshots/template/src/components/editor/slide-canvas.tsx
@@ -26,6 +26,7 @@ import {
 import { toTextElementId } from "@/lib/elements";
 import { img } from "@/lib/image-cache";
 import { pickText, resolveScreenshot } from "@/lib/locale";
+import { slideFontScales } from "@/lib/typography";
 import {
   AndroidPhone,
   AndroidTabletL,
@@ -233,6 +234,7 @@ function Caption({
 }) {
   const fg = inverted ? theme.fgAlt : theme.fg;
   const accent = theme.accent;
+  const { labelScale, headlineScale } = slideFontScales(slide);
   // Scale typography off the *shorter* dimension so landscape layouts don't
   // produce headlines so tall they overlap the device frame.
   const unit = Math.min(cW, cH);
@@ -245,9 +247,9 @@ function Caption({
         onFocus={onFocus}
         placeholder="LABEL"
         style={{
-          fontSize: unit * 0.028,
+          fontSize: unit * 0.028 * labelScale,
           fontWeight: 600,
-          letterSpacing: unit * 0.0015,
+          letterSpacing: unit * 0.0015 * labelScale,
           color: accent,
           textTransform: "uppercase",
           marginBottom: unit * 0.018,
@@ -262,10 +264,10 @@ function Caption({
         onFocus={onFocus}
         placeholder="Headline goes here"
         style={{
-          fontSize: unit * 0.092,
+          fontSize: unit * 0.092 * headlineScale,
           fontWeight: 700,
           lineHeight: 0.96,
-          letterSpacing: -unit * 0.001,
+          letterSpacing: -unit * 0.001 * headlineScale,
           color: fg,
         }}
       />
@@ -804,6 +806,7 @@ function FeatureGraphicCanvas({
   editable?: boolean;
   edit?: EditHandlers;
 }) {
+  const { headlineScale, appNameScale } = slideFontScales(slide);
   return (
     <div
       style={{
@@ -845,7 +848,7 @@ function FeatureGraphicCanvas({
               justifyContent: "center",
               color: theme.fgAlt,
               fontWeight: 800,
-              fontSize: cW * 0.07,
+              fontSize: cW * 0.07 * appNameScale,
               boxShadow: "0 4px 16px rgba(0,0,0,0.3)",
             }}
           >
@@ -853,14 +856,14 @@ function FeatureGraphicCanvas({
           </div>
         )}
         <div>
-          <div style={{ fontSize: cW * 0.06, fontWeight: 800, lineHeight: 1.05 }}>{appName || "App"}</div>
+          <div style={{ fontSize: cW * 0.06 * appNameScale, fontWeight: 800, lineHeight: 1.05 }}>{appName || "App"}</div>
           <EditableText
             value={pickText(slide.headline, locale)}
             editable={editable}
             multiline
             onChange={edit?.onHeadlineChange}
             style={{
-              fontSize: cW * 0.028,
+              fontSize: cW * 0.028 * headlineScale,
               color: "rgba(255,255,255,0.85)",
               marginTop: cW * 0.012,
               lineHeight: 1.25,

--- a/skills/app-store-screenshots/template/src/lib/storage.ts
+++ b/skills/app-store-screenshots/template/src/lib/storage.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { PROJECT_SCHEMA_VERSION, STORAGE_KEY } from "./constants";
 import { DEFAULT_PROJECT } from "./defaults";
 import { coerceLocalized } from "./locale";
+import { cleanTypography } from "./typography";
 import type { Device, ElementTransform, ProjectState, Slide, TextElement } from "./types";
 
 const HISTORY_LIMIT = 50;
@@ -71,6 +72,7 @@ function migrateSlide(slide: Slide): Slide {
     ...slide,
     label: coerceLocalized(slide.label as unknown),
     headline: coerceLocalized(slide.headline as unknown),
+    typography: cleanTypography(slide.typography),
     ...(transforms && Object.keys(transforms).length > 0 ? { transforms } : { transforms: undefined }),
     ...(textElements && textElements.length > 0 ? { textElements } : { textElements: undefined }),
   };

--- a/skills/app-store-screenshots/template/src/lib/types.ts
+++ b/skills/app-store-screenshots/template/src/lib/types.ts
@@ -55,6 +55,15 @@ export type TextElement = {
   align?: "left" | "center" | "right";
 };
 
+export type SlideTypography = {
+  /** Uppercase label above the headline (default 1). */
+  labelScale?: number;
+  /** Main headline, or feature-graphic tagline (default 1). */
+  headlineScale?: number;
+  /** Feature graphic app name only (default 1). */
+  appNameScale?: number;
+};
+
 export type Slide = {
   id: string;
   layout: SlideLayout;
@@ -63,6 +72,8 @@ export type Slide = {
   screenshot: string;         // path under /screenshots/ — may contain {locale}
   screenshotSecondary?: string; // for two-devices layout — may contain {locale}
   inverted?: boolean;         // dark background variant
+  /** Optional relative font-size scales for built-in caption text. */
+  typography?: SlideTypography;
   // Per-element overrides; when present, replaces layout default placement.
   transforms?: Partial<Record<BuiltInElementId, ElementTransform>>;
   textElements?: TextElement[];

--- a/skills/app-store-screenshots/template/src/lib/typography.ts
+++ b/skills/app-store-screenshots/template/src/lib/typography.ts
@@ -1,0 +1,35 @@
+import type { Slide, SlideTypography } from "./types";
+
+/** Relative scale on layout default font sizes (1 = default). */
+export const FONT_SCALE_MIN = 0.5;
+export const FONT_SCALE_MAX = 2;
+export const FONT_SCALE_DEFAULT = 1;
+
+export function clampFontScale(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return FONT_SCALE_DEFAULT;
+  return Math.min(FONT_SCALE_MAX, Math.max(FONT_SCALE_MIN, value));
+}
+
+export function slideFontScales(slide: Slide) {
+  return {
+    labelScale: clampFontScale(slide.typography?.labelScale),
+    headlineScale: clampFontScale(slide.typography?.headlineScale),
+    appNameScale: clampFontScale(slide.typography?.appNameScale),
+  };
+}
+
+/** Persist only non-default scales so JSON stays tidy. */
+export function cleanTypography(raw: SlideTypography | undefined): SlideTypography | undefined {
+  if (!raw) return undefined;
+  const out: SlideTypography = {};
+  if (raw.labelScale !== undefined && raw.labelScale !== FONT_SCALE_DEFAULT) {
+    out.labelScale = clampFontScale(raw.labelScale);
+  }
+  if (raw.headlineScale !== undefined && raw.headlineScale !== FONT_SCALE_DEFAULT) {
+    out.headlineScale = clampFontScale(raw.headlineScale);
+  }
+  if (raw.appNameScale !== undefined && raw.appNameScale !== FONT_SCALE_DEFAULT) {
+    out.appNameScale = clampFontScale(raw.appNameScale);
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}


### PR DESCRIPTION
## Summary

- Adds optional **Typography** controls in the screenshot editor inspector: per-slide relative font scales (50–200%) for **Label**, **Headline**, and (on feature graphics) **App name** / **Tagline**
- Persists scales in `slide.typography` in project JSON; only non-default values are stored
- Applies scales when rendering built-in captions and feature-graphic text in `slide-canvas.tsx`
- Improves custom **text element** sizing with a range slider plus the existing numeric input

This mirrors controls added while using the editor in production for [Road to Germany](https://github.com/dlg95/ETest) — useful when store copy needs tighter headlines or longer labels without changing layout.

## Test plan

- [ ] Open the editor template locally (`skills/app-store-screenshots/template`)
- [ ] Select a slide → adjust **Label** and **Headline** typography sliders → confirm canvas updates live
- [ ] Switch to feature-graphic device → confirm **Tagline** and **App name** sliders work
- [ ] Add a custom text element → use the new size range slider
- [ ] Save project JSON → confirm `typography` appears only when scales differ from 100%
- [ ] Reload editor → confirm scales are restored


Made with [Cursor](https://cursor.com)