### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # App Store & Google Play Screenshots Generator
 
+[![Listed on TakoAPI](https://takoapi.com/api/badge/parthjadhav-app-store-screenshots)](https://takoapi.com/agents/parthjadhav-app-store-screenshots)
+
 A skill for AI coding agents that scaffolds a production-ready Next.js editor for App Store and Google Play marketing screenshots. It gives you a connected canvas, real device frames, inspector controls, persistent project state, and one-click export bundles at store-ready sizes.
 
 ![Current connected-canvas editor showing a Bloom screenshot deck](example.png)


### PR DESCRIPTION
Hi! 👋 **app-store-screenshots** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/parthjadhav-app-store-screenshots

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building app-store-screenshots! 🙏