### PR TITLE
feat: add macOS and Windows screenshot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# App Store & Google Play Screenshots Generator
+# App Store, Microsoft Store & Google Play Screenshots Generator
 
-A skill for AI coding agents that scaffolds a production-ready Next.js editor for App Store and Google Play marketing screenshots. It gives you a connected canvas, real device frames, inspector controls, persistent project state, and one-click export bundles at store-ready sizes.
+A skill for AI coding agents that scaffolds a production-ready Next.js editor for App Store, Microsoft Store, and Google Play marketing screenshots. It gives you a connected canvas, real device frames, inspector controls, persistent project state, and one-click export bundles at store-ready sizes.
 
 ![Current connected-canvas editor showing a Bloom screenshot deck](example.png)
 
@@ -14,8 +14,8 @@ Example screenshots generated with this skill were accepted for [Bloom Coffee Sh
 - Keeps older projects safe with isolated-screen export mode until you opt into connected crops
 - Saves every deck to `app-store-screenshots.json`, so the project is git-trackable and resumable
 - Uploads picked screenshots into `public/screenshots/uploaded/<hash>.png`
-- Supports iOS, iPad, Android phone, Android tablet, and Play Store feature graphic decks
-- Exports exact PNG bundles for all required App Store and Google Play sizes
+- Supports iOS, iPad, Android phone, Android tablet, macOS, Windows, and Play Store feature graphic decks
+- Exports PNG bundles at common App Store, Microsoft Store, and Google Play sizes
 - Supports locales, RTL-aware copy/layout guidance, reusable themes, and in-place project migration
 
 ## Current Editor UI
@@ -24,8 +24,8 @@ Example screenshots generated with this skill were accepted for [Bloom Coffee Sh
 - **Isolated mode** - preserve legacy decks where offscreen elements should not leak into neighboring exports.
 - **Screen sidebar** - add, select, and drag-to-reorder screens with live thumbnails.
 - **Inspector** - edit layout, labels, headlines, screenshots, element stacking, and transforms from the right panel.
-- **Platform switcher** - keep iOS and Android decks side by side while sharing the same editor workflow.
-- **Device selector** - design for iPhone, iPad, Android phone, Android tablets, and feature graphic formats.
+- **Platform switcher** - keep iOS, Android, and Desktop decks side by side while sharing the same editor workflow.
+- **Device selector** - design for iPhone, iPad, Android phone, Android tablets, macOS, Windows, and feature graphic formats.
 - **Autosave** - writes to disk through `/api/project` and mirrors to `localStorage` for instant reloads.
 - **Export bundle** - downloads a zip organized by platform, device, resolution, and locale.
 

--- a/skills/app-store-screenshots/SKILL.md
+++ b/skills/app-store-screenshots/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: app-store-screenshots
-description: Use when building App Store or Google Play screenshot pages, generating exportable marketing screenshots for iOS and/or Android apps, or scaffolding a screenshot editor with Next.js. Triggers on app store, play store, screenshots, marketing assets, html-to-image, phone mockup, android screenshots, feature graphic.
+description: Use when building App Store, Microsoft Store, or Google Play screenshot pages, generating exportable marketing screenshots for iOS, Android, macOS, and/or Windows apps, or scaffolding a screenshot editor with Next.js. Triggers on app store, play store, microsoft store, screenshots, marketing assets, html-to-image, device mockup, desktop screenshots, feature graphic.
 ---
 
 # App Store & Google Play Screenshots Generator
@@ -14,7 +14,7 @@ Scaffold a pre-built Next.js + ShadCN editor that lets the user design and expor
 - Cross-screen mockups: phone/device frames, captions, and layered elements can be moved across adjacent screens, then exported as clipped crops
 - Drop-target screenshot picker (file → saved to `public/screenshots/uploaded/<hash>.png`)
 - Auto-save to **`app-store-screenshots.json`** at the project root (git-trackable) + `localStorage` mirror
-- Easy iOS ↔ Android platform switch — separate slide decks live side by side
+- Easy iOS ↔ Android ↔ Desktop platform switch — separate slide decks live side by side
 - One-click bulk PNG export at every Apple/Google-required resolution via `html-to-image`
 - Light/dark variant toggle per slide, theme presets, locale select
 - Guided in-place migration for older projects created by this skill; passive and explicit migrations keep legacy decks isolated until the user intentionally opts into connected canvas
@@ -26,6 +26,8 @@ Supported devices out of the box:
 - **Android Tablet 7"** (portrait + landscape) — Google Play
 - **Android Tablet 10"** (portrait + landscape) — Google Play
 - **Feature Graphic** (1024×500 banner) — Google Play store listing header
+- **macOS** (16:10 desktop window) — Mac App Store and product listings
+- **Windows** (16:9 desktop window) — Microsoft Store and product listings
 
 ## Core Principle
 
@@ -131,7 +133,7 @@ const path = require("path");
 
 const PROJECT_FILE = "app-store-screenshots.json";
 const DEFAULT_LOCALE = "en";
-const DEVICE_KEYS = ["iphone", "ipad", "android", "android-7", "android-10", "feature-graphic"];
+const DEVICE_KEYS = ["iphone", "ipad", "android", "android-7", "android-10", "macos", "windows", "feature-graphic"];
 const LAYOUTS = ["hero", "device-bottom", "device-top", "two-devices", "no-device", "split-landscape", "feature-graphic"];
 
 function readJson(file) {
@@ -453,7 +455,7 @@ Vary the `layout` field across slides. The editor exposes:
 - `device-top` — flipped, device above caption (good contrast slide)
 - `two-devices` — back + front phones layered
 - `no-device` — big standalone headline (use sparingly)
-- `split-landscape` — caption left + device right (tablet landscape only)
+- `split-landscape` — caption left + device right (tablet landscape and desktop)
 - `feature-graphic` — Play Store banner (1024×500)
 
 Never repeat the same layout twice in a row. Use 1-2 `inverted` (dark) slides for visual rhythm.
@@ -692,7 +694,7 @@ When you finish scaffolding, **start the dev server** (`bun dev` / `pnpm dev` / 
    bun dev       # → http://localhost:3000
    ```
    Substitute `pnpm` / `yarn` / `npm run` as appropriate for what was detected in Step 2.
-3. Which platforms have starter decks seeded (iOS, Android, or both).
+3. Which platforms have starter decks seeded (iOS, Android, Desktop, or a combination).
 4. Any user-supplied screenshots that didn't match the expected filenames (so they can rename or use the in-editor drop target).
 5. Point them at the **Export bundle** button once they're happy with the layouts.
 6. **Invite further edits:** say something like _"Feel free to ask me to make any changes you'd like to the screenshots — copy, layout, palette, anything. I can iterate with you."_

--- a/skills/app-store-screenshots/template/README.md
+++ b/skills/app-store-screenshots/template/README.md
@@ -1,6 +1,6 @@
-# App Store Screenshots — Editor Template
+# Store Screenshots — Editor Template
 
-A pre-built Next.js + ShadCN editor for generating App Store and Google Play screenshots. Scaffolded by the `app-store-screenshots` skill.
+A pre-built Next.js + ShadCN editor for generating App Store, Microsoft Store, and Google Play screenshots. Scaffolded by the `app-store-screenshots` skill.
 
 ## Quick start
 
@@ -13,9 +13,9 @@ bun dev       # http://localhost:3000
 
 - **Connected canvas editor** (`src/components/editor/`) — every screen sits on one horizontal canvas, so phones, captions, and other elements can be dragged across screen boundaries and exported as split crops when Connected mode is enabled.
 - **Screen controls** — drag-to-reorder screens, click-to-edit text, screenshot drop targets, per-screen layout switcher, dark/light toggle.
-- **Device frames** (`src/components/editor/device-frames.tsx`) — iPhone (PNG mockup), iPad, Android phone, Android tablet (portrait + landscape), feature graphic.
+- **Device frames** (`src/components/editor/device-frames.tsx`) — iPhone (PNG mockup), iPad, Android phone, Android tablet (portrait + landscape), macOS and Windows desktop windows, feature graphic.
 - **Auto-save (git-trackable)** — every change is persisted within ~600ms to **`app-store-screenshots.json`** at the project root (via `/api/project`) **and** mirrored to `localStorage` as an instant-paint cache. Commit `app-store-screenshots.json` and you can `git clone` to another machine and resume exactly where you left off.
-- **Multi-device decks** — iOS and Android slide decks live side by side; switching the platform tab preserves both.
+- **Multi-device decks** — iOS, Android, and Desktop slide decks live side by side; switching the platform tab preserves all three.
 - **One-click export** — bulk PNG export at any required App Store / Play Store resolution using `html-to-image`; each PNG is rendered from the current connected or isolated deck mode.
 - **Project migration** — older `app-store-screenshots.json` files are migrated on load. Existing per-slide transforms remain valid, and connected crops become available without rewriting the deck by hand.
 - **Legacy-safe mode** — pre-v2 projects opened directly in the editor start in isolated-screen mode first, then can opt into connected crops with the toolbar's Connected/Isolated control. Skill-run in-place migrations keep legacy decks isolated unless the project had already explicitly opted into connected canvas.
@@ -29,6 +29,8 @@ Two ways:
    - `public/screenshots/apple/iphone/en/...`
    - `public/screenshots/android/phone/en/...`
    - `public/screenshots/apple/ipad/en/...`
+   - `public/screenshots/desktop/macos/en/...`
+   - `public/screenshots/desktop/windows/en/...`
 
 Update the matching `screenshot` fields in `app-store-screenshots.json` to point at whatever filenames you choose.
 

--- a/skills/app-store-screenshots/template/app-store-screenshots.json
+++ b/skills/app-store-screenshots/template/app-store-screenshots.json
@@ -346,6 +346,54 @@
         "screenshot": ""
       }
     ],
+    "macos": [
+      {
+        "id": "s_desktop_mac_1",
+        "layout": "hero",
+        "label": { "en": "MADE FOR MACOS" },
+        "headline": { "en": "Your best work,\nfront and center." },
+        "screenshot": ""
+      },
+      {
+        "id": "s_desktop_mac_2",
+        "layout": "split-landscape",
+        "label": { "en": "FEATURE 01" },
+        "headline": { "en": "More room for\nwhat matters." },
+        "screenshot": ""
+      },
+      {
+        "id": "s_desktop_mac_3",
+        "layout": "device-top",
+        "label": { "en": "FEATURE 02" },
+        "headline": { "en": "Designed for your desktop." },
+        "screenshot": "",
+        "inverted": true
+      }
+    ],
+    "windows": [
+      {
+        "id": "s_desktop_windows_1",
+        "layout": "hero",
+        "label": { "en": "MADE FOR WINDOWS" },
+        "headline": { "en": "Your best work,\nfront and center." },
+        "screenshot": ""
+      },
+      {
+        "id": "s_desktop_windows_2",
+        "layout": "split-landscape",
+        "label": { "en": "FEATURE 01" },
+        "headline": { "en": "More room for\nwhat matters." },
+        "screenshot": ""
+      },
+      {
+        "id": "s_desktop_windows_3",
+        "layout": "device-top",
+        "label": { "en": "FEATURE 02" },
+        "headline": { "en": "Designed for your desktop." },
+        "screenshot": "",
+        "inverted": true
+      }
+    ],
     "feature-graphic": [
       {
         "id": "s_mppgoot8_h",
@@ -364,6 +412,8 @@
     "android": [],
     "android-7": [],
     "android-10": [],
+    "macos": [],
+    "windows": [],
     "feature-graphic": []
   }
 }

--- a/skills/app-store-screenshots/template/src/components/editor/device-frames.tsx
+++ b/skills/app-store-screenshots/template/src/components/editor/device-frames.tsx
@@ -275,6 +275,79 @@ export function IPad({ src, alt = "", style, hideEmpty }: FrameProps) {
   );
 }
 
+export function MacOSWindow(props: FrameProps) {
+  return <DesktopWindow {...props} platform="macos" />;
+}
+
+export function WindowsWindow(props: FrameProps) {
+  return <DesktopWindow {...props} platform="windows" />;
+}
+
+function DesktopWindow({
+  src,
+  alt = "",
+  style,
+  hideEmpty,
+  platform,
+}: FrameProps & { platform: "macos" | "windows" }) {
+  const resolved = img(src);
+  const isMac = platform === "macos";
+  return (
+    <div style={{ position: "relative", aspectRatio: isMac ? "16 / 10" : "16 / 9", ...style }}>
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          borderRadius: isMac ? "2.2% / 3.5%" : "1.2% / 2.1%",
+          background: isMac ? "#d8d8dc" : "#e8e8e8",
+          boxShadow: "0 18px 60px rgba(0,0,0,0.35), inset 0 0 0 1px rgba(0,0,0,0.18)",
+          overflow: "hidden",
+          position: "relative",
+        }}
+      >
+        <div
+          style={{
+            height: "7%",
+            display: "flex",
+            alignItems: "center",
+            padding: "0 1.4%",
+            background: isMac ? "linear-gradient(#f4f4f5, #dedee1)" : "#f3f3f3",
+            borderBottom: "1px solid rgba(0,0,0,0.15)",
+          }}
+        >
+          {isMac ? (
+            <div style={{ display: "flex", gap: "0.55%", width: "100%" }}>
+              {["#ff5f57", "#febc2e", "#28c840"].map((color) => (
+                <span key={color} style={{ width: "1.15%", aspectRatio: "1", borderRadius: "50%", background: color }} />
+              ))}
+            </div>
+          ) : (
+            <>
+              <span style={{ width: "1.1%", aspectRatio: "1", background: "#0078d4", marginRight: "1%" }} />
+              <span style={{ width: "25%", height: "34%", borderRadius: 3, background: "rgba(0,0,0,0.08)" }} />
+              <div style={{ marginLeft: "auto", display: "flex", gap: "1.8em", fontSize: "min(1.4vw, 18px)", color: "#333" }}>
+                <span>−</span><span>□</span><span>×</span>
+              </div>
+            </>
+          )}
+        </div>
+        <div style={{ width: "100%", height: "93%", overflow: "hidden", background: "#111" }}>
+          {resolved ? (
+            <img
+              src={resolved}
+              alt={alt}
+              style={{ display: "block", width: "100%", height: "100%", objectFit: "cover", objectPosition: "top" }}
+              draggable={false}
+            />
+          ) : hideEmpty ? null : (
+            <EmptySlot />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function EmptySlot() {
   return (
     <div

--- a/skills/app-store-screenshots/template/src/components/editor/slide-canvas.tsx
+++ b/skills/app-store-screenshots/template/src/components/editor/slide-canvas.tsx
@@ -17,6 +17,7 @@ import {
   CANVAS,
   IPAD_RATIO,
   MK_RATIO,
+  desktopW,
   ipadW,
   phoneW,
   phoneWSmall,
@@ -31,7 +32,9 @@ import {
   AndroidTabletL,
   AndroidTabletP,
   IPad,
+  MacOSWindow,
   Phone,
+  WindowsWindow,
 } from "./device-frames";
 
 type FrameComp = React.ComponentType<{
@@ -57,6 +60,8 @@ function getFrameAspect(device: Device, orientation: Orientation) {
     case "ipad":        return IPAD_RATIO;
     case "android-7":
     case "android-10":  return orientation === "landscape" ? 8 / 5 : 5 / 8;
+    case "macos":       return 16 / 10;
+    case "windows":     return 16 / 9;
     default:            return 1;
   }
 }
@@ -79,6 +84,18 @@ export function getFrameForDevice(device: Device, orientation: Orientation): {
         return { Comp: AndroidTabletL, widthFn: tabletLW, smallWidthFn: (cW, cH) => tabletLW(cW, cH, 0.5) };
       }
       return { Comp: AndroidTabletP, widthFn: tabletPW, smallWidthFn: (cW, cH) => tabletPW(cW, cH, 0.62) };
+    case "macos":
+      return {
+        Comp: MacOSWindow,
+        widthFn: (cW, cH) => desktopW(cW, cH, 16 / 10),
+        smallWidthFn: (cW, cH) => desktopW(cW, cH, 16 / 10, 0.58),
+      };
+    case "windows":
+      return {
+        Comp: WindowsWindow,
+        widthFn: (cW, cH) => desktopW(cW, cH, 16 / 9),
+        smallWidthFn: (cW, cH) => desktopW(cW, cH, 16 / 9, 0.58),
+      };
     default:
       return { Comp: Phone, widthFn: phoneW, smallWidthFn: phoneWSmall };
   }

--- a/skills/app-store-screenshots/template/src/components/editor/toolbar.tsx
+++ b/skills/app-store-screenshots/template/src/components/editor/toolbar.tsx
@@ -23,7 +23,7 @@ import {
   supportsLandscape,
 } from "@/lib/constants";
 import { detectPlatform } from "@/lib/defaults";
-import type { Device, Orientation } from "@/lib/types";
+import type { Device, Orientation, Platform } from "@/lib/types";
 
 type Props = {
   appName: string;
@@ -51,10 +51,11 @@ export function Toolbar(props: Props) {
   const hasLandscape = supportsLandscape(props.device);
   const [resetOpen, setResetOpen] = React.useState(false);
 
-  // Track last device per platform so iOS/Android tabs preserve user's choice.
-  const lastByPlatform = React.useRef<{ ios: Device; android: Device }>({
+  // Track last device per platform so tabs preserve the user's previous target.
+  const lastByPlatform = React.useRef<Record<Platform, Device>>({
     ios: platform === "ios" ? props.device : "iphone",
     android: platform === "android" ? props.device : "android",
+    desktop: platform === "desktop" ? props.device : "macos",
   });
   React.useEffect(() => {
     lastByPlatform.current[platform] = props.device;
@@ -102,8 +103,7 @@ export function Toolbar(props: Props) {
         value={platform}
         onValueChange={(p) => {
           if (props.busy) return;
-          const next = p === "ios" ? lastByPlatform.current.ios : lastByPlatform.current.android;
-          props.setDevice(next);
+          props.setDevice(lastByPlatform.current[p as Platform]);
         }}
       >
         <TabsList className="h-8 p-0.5">
@@ -112,6 +112,9 @@ export function Toolbar(props: Props) {
           </TabsTrigger>
           <TabsTrigger value="android" className="h-7 px-3 text-xs" disabled={props.busy}>
             Android
+          </TabsTrigger>
+          <TabsTrigger value="desktop" className="h-7 px-3 text-xs" disabled={props.busy}>
+            Desktop
           </TabsTrigger>
         </TabsList>
       </Tabs>
@@ -130,12 +133,17 @@ export function Toolbar(props: Props) {
               <SelectItem value="iphone">{DEVICE_LABEL.iphone}</SelectItem>
               <SelectItem value="ipad">{DEVICE_LABEL.ipad}</SelectItem>
             </>
-          ) : (
+          ) : platform === "android" ? (
             <>
               <SelectItem value="android">{DEVICE_LABEL.android}</SelectItem>
               <SelectItem value="android-7">{DEVICE_LABEL["android-7"]}</SelectItem>
               <SelectItem value="android-10">{DEVICE_LABEL["android-10"]}</SelectItem>
               <SelectItem value="feature-graphic">{DEVICE_LABEL["feature-graphic"]}</SelectItem>
+            </>
+          ) : (
+            <>
+              <SelectItem value="macos">{DEVICE_LABEL.macos}</SelectItem>
+              <SelectItem value="windows">{DEVICE_LABEL.windows}</SelectItem>
             </>
           )}
         </SelectContent>

--- a/skills/app-store-screenshots/template/src/lib/constants.ts
+++ b/skills/app-store-screenshots/template/src/lib/constants.ts
@@ -7,6 +7,8 @@ export const CANVAS: Record<Device, { w: number; h: number; wL?: number; hL?: nu
   android:       { w: 1080, h: 1920 },
   "android-7":   { w: 1200, h: 1920, wL: 1920, hL: 1200 },
   "android-10":  { w: 1600, h: 2560, wL: 2560, hL: 1600 },
+  macos:         { w: 2880, h: 1800 },
+  windows:       { w: 2560, h: 1440 },
   "feature-graphic": { w: 1024, h: 500 },
 };
 
@@ -27,6 +29,16 @@ export const EXPORT_SIZES: Record<Device, ExportSize[]> = {
   android:       [{ label: "Phone",          w: 1080, h: 1920 }],
   "android-7":   [{ label: '7" Portrait',    w: 1200, h: 1920 }],
   "android-10":  [{ label: '10" Portrait',   w: 1600, h: 2560 }],
+  macos: [
+    { label: "2880 × 1800", w: 2880, h: 1800 },
+    { label: "2560 × 1600", w: 2560, h: 1600 },
+    { label: "1440 × 900",  w: 1440, h: 900 },
+  ],
+  windows: [
+    { label: "2560 × 1440", w: 2560, h: 1440 },
+    { label: "1920 × 1080", w: 1920, h: 1080 },
+    { label: "1366 × 768",  w: 1366, h: 768 },
+  ],
   "feature-graphic": [{ label: "Feature Graphic", w: 1024, h: 500 }],
 };
 
@@ -78,6 +90,9 @@ export function tabletLW(cW: number, cH: number, clamp = 0.62) {
 }
 export function ipadW(cW: number, cH: number, clamp = 0.75) {
   return Math.min(clamp, 0.72 * (cH / cW) * IPAD_RATIO);
+}
+export function desktopW(cW: number, cH: number, aspect: number, clamp = 0.72) {
+  return Math.min(clamp, 0.68 * (cH / cW) * aspect);
 }
 
 // ---------- Themes ----------
@@ -153,6 +168,8 @@ export const DEVICE_LABEL: Record<Device, string> = {
   android: "Android Phone",
   "android-7": 'Android 7" Tablet',
   "android-10": 'Android 10" Tablet',
+  macos: "macOS",
+  windows: "Windows",
   "feature-graphic": "Feature Graphic",
 };
 

--- a/skills/app-store-screenshots/template/src/lib/defaults.ts
+++ b/skills/app-store-screenshots/template/src/lib/defaults.ts
@@ -95,6 +95,33 @@ function tabletStarter(kind: "7" | "10"): Slide[] {
   ];
 }
 
+function desktopStarter(platform: "macOS" | "Windows"): Slide[] {
+  return [
+    {
+      id: nid(),
+      layout: "hero",
+      label: en(`MADE FOR ${platform.toUpperCase()}`),
+      headline: en("Your best work,\nfront and center."),
+      screenshot: "",
+    },
+    {
+      id: nid(),
+      layout: "split-landscape",
+      label: en("FEATURE 01"),
+      headline: en("More room for\nwhat matters."),
+      screenshot: "",
+    },
+    {
+      id: nid(),
+      layout: "device-top",
+      label: en("FEATURE 02"),
+      headline: en("Designed for your desktop."),
+      screenshot: "",
+      inverted: true,
+    },
+  ];
+}
+
 function fgStarter(): Slide[] {
   return [
     {
@@ -123,6 +150,8 @@ export const DEFAULT_PROJECT: ProjectState = {
     ipad: ipadStarter(),
     "android-7": tabletStarter("7"),
     "android-10": tabletStarter("10"),
+    macos: desktopStarter("macOS"),
+    windows: desktopStarter("Windows"),
     "feature-graphic": fgStarter(),
   },
 };
@@ -137,6 +166,8 @@ export function newSlide(layout: Slide["layout"] = "device-bottom"): Slide {
   };
 }
 
-export function detectPlatform(device: Device): "ios" | "android" {
-  return device === "iphone" || device === "ipad" ? "ios" : "android";
+export function detectPlatform(device: Device): "ios" | "android" | "desktop" {
+  if (device === "iphone" || device === "ipad") return "ios";
+  if (device === "macos" || device === "windows") return "desktop";
+  return "android";
 }

--- a/skills/app-store-screenshots/template/src/lib/types.ts
+++ b/skills/app-store-screenshots/template/src/lib/types.ts
@@ -4,11 +4,13 @@ export type Device =
   | "android"
   | "android-7"
   | "android-10"
+  | "macos"
+  | "windows"
   | "feature-graphic";
 
 export type Orientation = "portrait" | "landscape";
 
-export type Platform = "ios" | "android";
+export type Platform = "ios" | "android" | "desktop";
 
 // Layouts the editor can render. Vary across slides for visual rhythm.
 export type SlideLayout =


### PR DESCRIPTION
## Summary

- add a Desktop platform with separate macOS and Windows screenshot decks
- add responsive 16:10 macOS and 16:9 Windows window frames, desktop starter layouts, and common export resolutions
- update template state, migration device keys, asset path guidance, and project documentation

## Validation

- VS Code diagnostics: no errors across the template src directory
- canonical app-store-screenshots.json parses successfully
- git diff --check passes
- full Next.js build not run because the configured npm registry does not provide the template-pinned next@15.0.3 package