### PR TITLE
fix: reject cross-site writes on the disk-writing API routes

### DIFF
--- a/skills/app-store-screenshots/template/.gitignore
+++ b/skills/app-store-screenshots/template/.gitignore
@@ -5,3 +5,7 @@ out
 *.tsbuildinfo
 next-env.d.ts
 .env*.local
+
+# User-uploaded screenshots land here at runtime. They are the user's assets,
+# not template content, and must never be committed back into the template.
+public/screenshots/uploaded/

--- a/skills/app-store-screenshots/template/src/app/api/project/route.ts
+++ b/skills/app-store-screenshots/template/src/app/api/project/route.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { NextResponse } from "next/server";
+import { rejectCrossSiteWrite } from "@/lib/request-guard";
 
 export const dynamic = "force-dynamic";
 
@@ -28,6 +29,11 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
+  // This route OVERWRITES a git-tracked file. See lib/request-guard.ts.
+  const blocked = rejectCrossSiteWrite(req);
+  if (blocked) {
+    return NextResponse.json({ ok: false, error: blocked.error }, { status: blocked.status });
+  }
   let body: unknown;
   try {
     body = await req.json();

--- a/skills/app-store-screenshots/template/src/app/api/upload/route.ts
+++ b/skills/app-store-screenshots/template/src/app/api/upload/route.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { NextResponse } from "next/server";
+import { rejectCrossSiteWrite, sniffImageType } from "@/lib/request-guard";
 
 export const dynamic = "force-dynamic";
 
@@ -23,6 +24,11 @@ function parseDataUrl(dataUrl: string): { mime: string; bytes: Buffer } | null {
 }
 
 export async function POST(req: Request) {
+  // This route WRITES A FILE to disk. See lib/request-guard.ts.
+  const blocked = rejectCrossSiteWrite(req);
+  if (blocked) {
+    return NextResponse.json({ ok: false, error: blocked.error }, { status: blocked.status });
+  }
   let body: { dataUrl?: string };
   try {
     body = (await req.json()) as { dataUrl?: string };
@@ -40,6 +46,15 @@ export async function POST(req: Request) {
   if (!ext) {
     return NextResponse.json(
       { ok: false, error: `Unsupported mime: ${parsed.mime}` },
+      { status: 400 },
+    );
+  }
+  // The declared MIME comes from the caller-written data URL, so it decides
+  // the stored extension. Require the bytes to actually be that image type.
+  const sniffed = sniffImageType(parsed.bytes);
+  if (!sniffed || MIME_EXT[sniffed] !== ext) {
+    return NextResponse.json(
+      { ok: false, error: "Content does not match declared image type" },
       { status: 400 },
     );
   }

--- a/skills/app-store-screenshots/template/src/lib/request-guard.ts
+++ b/skills/app-store-screenshots/template/src/lib/request-guard.ts
@@ -1,0 +1,92 @@
+/**
+ * Guards for the two API routes that WRITE TO DISK.
+ *
+ * THE EXPOSURE
+ * ------------
+ * `POST /api/upload` writes a file into `public/screenshots/uploaded/`, and
+ * `POST /api/project` OVERWRITES `app-store-screenshots.json`, which is
+ * normally git-tracked. Neither had an origin check.
+ *
+ * While the dev server is running, any page in any other tab can send a
+ * cross-origin POST. If that request is a CORS-"simple" request — which
+ * `Content-Type: text/plain` makes it — the browser sends it WITH NO
+ * PREFLIGHT. The attacker cannot read the response, and does not need to: the
+ * write has already happened. `Request.json()` ignores the declared
+ * Content-Type and parses the body anyway, so a text/plain body containing
+ * JSON is accepted.
+ *
+ * Realistic harm: a malicious page plants files inside the user's repository,
+ * or blanks the canonical project state, while they have the editor open.
+ *
+ * "It only listens on localhost" is NOT a defence. The victim's own browser is
+ * inside localhost, and it is the browser that makes the request.
+ *
+ * THE GUARD
+ * ---------
+ * `rejectCrossSiteWrite` applies three checks, in increasing specificity:
+ *
+ *  1. Require `Content-Type: application/json`. This is the load-bearing one.
+ *     That header is NOT CORS-simple, so requiring it forces the browser to
+ *     send a preflight, and the preflight fails because these routes send no
+ *     CORS headers. This alone closes the no-preflight hole.
+ *  2. Reject a non-loopback `Origin`.
+ *  3. Reject a cross-site `Sec-Fetch-Site`.
+ *
+ * Checks 2 and 3 SKIP WHEN THE HEADER IS ABSENT. That is deliberate, and it is
+ * not a hole: the attack vector here is the victim's browser, and a browser
+ * cannot be made to omit those headers on a cross-origin request. Skipping on
+ * absence is what keeps curl, scripts and tests working.
+ *
+ * `sniffImageType` closes a separate issue: the stored file extension came
+ * from the MIME string inside the data URL, which the caller writes by hand,
+ * so arbitrary bytes could be stored as `<hash>.png`. This is not a path
+ * traversal — the filename is a content hash plus a whitelisted extension —
+ * and Next serves `public/` by extension, so it cannot be made to execute.
+ * The realistic harm is junk that looks like an image getting committed.
+ */
+
+const LOOPBACK = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+export type GuardFailure = { error: string; status: number };
+
+/**
+ * Returns a failure to respond with, or null when the request is allowed.
+ * Call at the top of every route handler that writes to disk.
+ */
+export function rejectCrossSiteWrite(req: Request): GuardFailure | null {
+  // 1. Content-Type must be application/json. Not CORS-simple, so a
+  //    cross-origin caller is forced into a preflight that fails.
+  const contentType = req.headers.get("content-type") || "";
+  if (!contentType.toLowerCase().split(";")[0].trim().startsWith("application/json")) {
+    return { error: "Content-Type must be application/json", status: 415 };
+  }
+
+  // 2. Origin, when present, must be loopback.
+  const origin = req.headers.get("origin");
+  if (origin && !LOOPBACK.test(origin)) {
+    return { error: "Cross-origin write rejected", status: 403 };
+  }
+
+  // 3. Sec-Fetch-Site, when present, must not be cross-site.
+  const site = req.headers.get("sec-fetch-site");
+  if (site && site !== "same-origin" && site !== "same-site" && site !== "none") {
+    return { error: "Cross-site write rejected", status: 403 };
+  }
+
+  return null;
+}
+
+/** Magic-byte sniff. Returns the real type, or null if it is neither. */
+export function sniffImageType(bytes: Buffer): "image/png" | "image/jpeg" | null {
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47 &&
+    bytes[4] === 0x0d && bytes[5] === 0x0a && bytes[6] === 0x1a && bytes[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return "image/jpeg";
+  }
+  return null;
+}


### PR DESCRIPTION
## The issue

`POST /api/upload` writes a file into `public/screenshots/uploaded/`, and `POST /api/project` **overwrites `app-store-screenshots.json`** — which users typically keep in git. Neither route has an origin check.

While the dev server is running, **any page in another tab can send a cross-origin POST**. With `Content-Type: text/plain` that request is CORS-"simple", so the browser sends it **with no preflight**. The attacker cannot read the response and doesn't need to — the write has already landed. `Request.json()` ignores the declared Content-Type and parses the body regardless, so a `text/plain` body containing JSON is accepted.

Binding to localhost is not a defence: the victim's own browser is inside localhost, and it is the browser that makes the request.

**Realistic impact:** a malicious page can plant files inside a user's repository, or blank the canonical project state, while they have the editor open.

**Separately**, the stored file extension came from the MIME string inside the caller-supplied data URL, so arbitrary bytes could be written as `<hash>.png`. This is *not* a path traversal — the filename is a content hash plus a whitelisted extension — and `public/` is served by extension so it can't be made to execute. The realistic harm is junk that looks like an image getting committed.

## The fix

New `src/lib/request-guard.ts`:

**`rejectCrossSiteWrite()`** on both POST handlers:
1. **Require `Content-Type: application/json`.** This is the load-bearing check — that header is not CORS-simple, so requiring it forces a preflight, and the preflight fails because these routes send no CORS headers.
2. Reject a non-loopback `Origin`.
3. Reject a cross-site `Sec-Fetch-Site`.

Checks 2 and 3 **skip when the header is absent**. That's deliberate rather than an oversight: the lever in this attack is the victim's browser, and a browser cannot be made to omit those headers on a cross-origin request. Skipping on absence keeps `curl`, scripts and tests working without opening a hole.

**`sniffImageType()`** — PNG/JPEG magic bytes must match the declared type.

Also ignores `public/screenshots/uploaded/`, which holds runtime user assets that shouldn't be committed back into the template.

## No behaviour change for the editor

Both existing callers already send `content-type: application/json` — `lib/storage.ts` and `components/editor/screenshot-picker.tsx`. I checked those before touching the routes.

## Verification

Tested in both directions, on the principle that a guard only ever exercised on good input is indistinguishable from no guard.

**Verified against the stack this PR actually ships** — `next 15.0.3` / `react 19.0.0-rc-66855b96-20241106`, installed with `bun install --frozen-lockfile` from the template's own `bun.lock`. `tsc --noEmit` and `next build` both clean, then the controls below run against `next start`.

*(An earlier run of these controls used a newer Next 16 / React 19.2 tree that happened to be on my machine. Same 8/8 result, but that was a true measurement of a configuration this PR does not ship, so I re-ran it properly against the declared lockfile. The table below is the Next 15.0.3 run.)*

**After the fix — 8/8:**

| Request | Expected | Got |
|---|---|---|
| project write, `application/json`, no Origin | 200 | 200 |
| upload valid PNG, `application/json` | 200 | 200 |
| project write, same-origin `Sec-Fetch-Site` | 200 | 200 |
| **the CSRF shape:** `text/plain`, no preflight | 415 | 415 |
| evil `Origin` | 403 | 403 |
| cross-site `Sec-Fetch-Site` | 403 | 403 |
| upload, `text/plain` CSRF shape | 415 | 415 |
| non-image bytes labelled `image/png` | 400 | 400 |

**Before the fix**, the same requests confirmed the issue was exploitable rather than theoretical:

- `text/plain` CSRF write → **200, and it actually rewrote `app-store-screenshots.json`** (`appName` became `"PWNED"`)
- evil `Origin` → **200**
- non-image bytes declared `image/png` → **200**, stored as `<hash>.png`

Happy to adjust the approach — in particular if you'd rather gate on a token than on headers, or if you want the `Sec-Fetch-Site` check to be strict rather than skip-on-absent.